### PR TITLE
Update media.txt

### DIFF
--- a/Sources/Client/media.txt
+++ b/Sources/Client/media.txt
@@ -1,253 +1,480 @@
  SYSTEM      MEDIA NAME (brief)   IMAGE FILE EXTENSIONS SUPPORTED     
 ----------  --------------------  ------------------------------------
-1292apvs     quickload   (quik)     .tvc  
+1292apvs     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-1392apvs     quickload   (quik)     .tvc  
+1392apvs     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 32x          cartridge   (cart)     .32x  .bin  
-32x_scd      cdrom       (cdrm)     .chd  
+32x_scd      cartridge   (cart)     .32x  .bin  
+32xe         cartridge   (cart)     .32x  .bin  
+32xj         cartridge   (cart)     .32x  .bin  
 3b1          floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-3do          cdrom       (cdrm)     .chd  
-3do_pal      cdrom       (cdrm)     .chd  
+3do          cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+3do_m2       (none)
+3do_pal      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 4004clk      (none)
 68ksbc       (none)
 990189       cassette    (cass)     .wav  
              serial      (serl)     .     
 990189v      cassette    (cass)     .wav  
              serial      (serl)     .     
+a1000        printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 a1000n       printer     (prin)     .prn  
-             floppydisk1 (flop1)    .adf  
-a1000p       printer     (prin)     .prn  
-             floppydisk1 (flop1)    .adf  
-a1200n       floppydisk1 (flop1)    .adf  
-a1200p       floppydisk1 (flop1)    .adf  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+a1200        printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+a1200n       printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 a1200xl      floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a130xe       floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a2600        cartridge   (cart)     .bin  .a26  
-             cassette    (cass)     .wav  .@a26  
+             cassette    (cass)     .wav  .a26  
 a2600p       cartridge   (cart)     .bin  .a26  
-             cassette    (cass)     .wav  .@a26  
-a3000        (none)
+             cassette    (cass)     .wav  .a26  
+a3000        printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+a3000n       printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+a3010        (none)
+a3020        (none)
 a310         (none)
 a400         floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a400pal      floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
+             cartridge   (cart)     .rom  .bin  
+a500         printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .rom  .bin  
 a500n        printer     (prin)     .prn  
-             floppydisk1 (flop)    .adf  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .rom  .bin  
-a500p        printer     (prin)     .prn  
-             floppydisk1 (flop)    .adf  
+a500pl       printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cartridge   (cart)     .rom  .bin  
+a500pln      printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .rom  .bin  
 a5105        cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 a5120        (none)
 a5130        (none)
 a5200        cartridge   (cart)     .rom  .bin  .a52  
+a600         printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cartridge   (cart)     .rom  .bin  
+a600n        printer     (prin)     .prn  
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cartridge   (cart)     .rom  .bin  
 a600xl       floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a65xe        floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a65xea       floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
-a6809        (none)
+a6809        cassette    (cass)     .wav  
 a7000        (none)
 a7000p       (none)
 a7150        (none)
 a7800        cartridge   (cart)     .bin  .a78  
 a7800p       cartridge   (cart)     .bin  .a78  
 a800         floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge1  (cart1)    .rom  .bin  
+             cartridge2  (cart2)    .rom  .bin  
 a800pal      floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge1  (cart1)    .rom  .bin  
+             cartridge2  (cart2)    .rom  .bin  
 a800xe       floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a800xl       floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
 a800xlp      floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
              cartridge   (cart)     .rom  .bin  
-abc          (none)
-abc1600      floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+abc1600      floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-abc80        printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-abc800c      printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-abc800m      printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-abc802       printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-abc806       printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+abc80        cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+abc800c      cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+abc800m      cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+abc802       cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+abc806       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ac1          cassette    (cass)     .wav  
 ac1_32       cassette    (cass)     .wav  
 ac1scch      cassette    (cass)     .wav  
-ace          cassette    (cass)     .wav  .tap  
-             snapshot    (dump)     .ace  
-             printer     (prin)     .prn  
+academy      (none)
 ace100       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
-acrnsys1     (none)
-adam         floppydisk  (flop)     .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette1   (cass1)    .wav  
+acrnsys1     cassette    (cass)     .wav  
+adam         cassette1   (cass1)    .wav  .ddp  
+             cassette2   (cass2)    .wav  .ddp  
+             floppydisk  (flop)     .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge1  (cart1)    .rom  .col  .bin  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+             cartridge4  (cart4)    .bin  .rom  
 advision     cartridge   (cart)     .bin  
 advsnha      cartridge   (cart)     .bin  
 aes          cartridge   (cart)     .bin  
 agat7        floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 agat9        floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 ai1000       cartridge1  (cart1)    .bin  
-aim65        cartridge1  (cart1)    .z26  
+             cartridge2  (cart2)    .bin  
+aim65        cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+             cartridge1  (cart1)    .z26  
+             cartridge2  (cart2)    .z25  
+             cartridge3  (cart3)    .z24  
 aim65_40     (none)
 al520ex      printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 al8800bt     quickload   (quik)     .bin  
-alfa         cassette    (cass)     .wav  .pmd  
+alfa         cassette    (cass)     .wav  .pmd  .tap  .ptp  
 alice        cassette    (cass)     .wav  .cas  
              printer     (prin)     .prn  
 alice32      cassette    (cass)     .wav  .cas  .c10  .k7   
              printer     (prin)     .prn  
 alice90      cassette    (cass)     .wav  .cas  .c10  .k7   
              printer     (prin)     .prn  
+alm16        (none)
+alm32        (none)
+alphasma     (none)
+alphatro     cassette    (cass)     .wav  
+altos5       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+am64         floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  
 amico2k      (none)
+ampro        floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 amsterd      (none)
 amu880       cassette    (cass)     .wav  
+apc          floppydisk1 (flop1)    .d77  .d88  .1dd  .imd  .mfi  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .imd  .mfi  
 apexc        cylinder    (cyln)     .apc  
              punchtape1  (ptap1)    .tap  
+             punchtape2  (ptap2)    .tap  
 apfimag      cassette    (cass)     .wav  .apt  
              floppydisk1 (flop1)    .apd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .apd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 apfm1000     cartridge   (cart)     .bin  
+aplannb      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+aplanst      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+aplsbon      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+aplscar      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
 apogee       cassette    (cass)     .wav  .rka  
-apollo80     cartridge   (cart)     .st2  .bin  
+apollo80     cartridge   (cart)     .st2  .bin  .rom  
 apple1       snapshot    (dump)     .snp  
              cassette    (cass)     .wav  
 apple2       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
-apple2c      floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
-apple2c0     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
-apple2c3     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
-apple2c4     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
-apple2cp     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
+apple2c      cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+apple2c0     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+apple2c3     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+apple2c4     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+apple2cp     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2e      floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 apple2ee     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
 apple2ep     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 apple2gs     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2gsr0   floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2gsr1   floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2gsr3lp floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2gsr3p  floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .img  .image.dc   .2img .2mg  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 apple2jp     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 apple2p      floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 apple3       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-applix       (none)
-apricot      floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-apricotxi    floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-aprif1       floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-aprif10      floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-aprifp       floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-aquarius     printer     (prin)     .prn  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+applix       printer     (prin)     .prn  
              cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+aprfte       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apricot      printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+apricotxi    printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+aprpand      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apvxft       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apxena1      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apxeni       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apxenls3     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apxenp2      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+apxlsam      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+aquarius     cassette    (cass)     .wav  
              cartridge   (cart)     .bin  
-aquarius_qd  printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 arcadia      cartridge   (cart)     .bin  
 argo         (none)
+asst128      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 astrocde     cartridge   (cart)     .bin  
 astrocdl     cartridge   (cart)     .bin  
 astrocdw     cartridge   (cart)     .bin  
-at           printer1    (prin1)    .prn  
+at           floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-at386        printer1    (prin1)    .prn  
+at386        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-at486        printer1    (prin1)    .prn  
+             printer     (prin)     .prn  
+at486        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-at586        printer1    (prin1)    .prn  
-             harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer     (prin)     .prn  
+at586        harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+at586x3      harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+ataripc3     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 atm          snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 atmtb2       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 atom         floppydisk1 (flop1)    .dsk  .40t  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .40t  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .uef  
              quickload   (quik)     .atm  
              cartridge   (cart)     .bin  .rom  
+atombb       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .uef  
 atomeb       floppydisk1 (flop1)    .dsk  .40t  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .40t  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .uef  
              quickload   (quik)     .atm  
              cartridge1  (cart1)    .bin  .rom  
-atvga        printer1    (prin1)    .prn  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+             cartridge4  (cart4)    .bin  .rom  
+             cartridge5  (cart5)    .bin  .rom  
+             cartridge6  (cart6)    .bin  .rom  
+             cartridge7  (cart7)    .bin  .rom  
+             cartridge8  (cart8)    .bin  .rom  
+             cartridge9  (cart9)    .bin  .rom  
+             cartridge10 (cart10)   .bin  .rom  
+             cartridge11 (cart11)   .bin  .rom  
+             cartridge12 (cart12)   .bin  .rom  
+             cartridge13 (cart13)   .bin  .rom  
+             cartridge14 (cart14)   .bin  .rom  
+             cartridge15 (cart15)   .bin  .rom  
+             cartridge16 (cart16)   .bin  .rom  
+             cartridge17 (cart17)   .bin  .rom  
+             cartridge18 (cart18)   .bin  .rom  
+attache      floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+attachef     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+atvga        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-avigo        (none)
+avigo        quickload   (quik)     .app  
+avigo_de     quickload   (quik)     .app  
+avigo_es     quickload   (quik)     .app  
+avigo_fr     quickload   (quik)     .app  
+avigo_it     quickload   (quik)     .app  
 ax170        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+ax20         floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 ax350        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 ax370        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-b128         quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-b128hp       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
+             cartridge2  (cart2)    .mx1  .rom  
+b128         floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+b128hp       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
 b16          (none)
-b256         quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-b256hp       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-b2m          floppydisk1 (flop1)    .cpm  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-b2mrom       floppydisk1 (flop1)    .cpm  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-b500         quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
+b256         floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+b256hp       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+b2m          floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+b2mrom       floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+b500         floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+babbage      (none)
 basic31      (none)
 basic52      (none)
 batmantv     (none)
@@ -255,343 +482,501 @@ bbca         cassette    (cass)     .wav  .csw  .uef
 bbcb         cassette    (cass)     .wav  .csw  .uef  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
+             cartridge3  (cart3)    .rom  
+             cartridge4  (cart4)    .rom  
 bbcbc        cartridge   (cart)     .bin  
 bbcbp        cassette    (cass)     .wav  .csw  .uef  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
+             cartridge3  (cart3)    .rom  
+             cartridge4  (cart4)    .rom  
 bbcbp128     cassette    (cass)     .wav  .csw  .uef  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
+             cartridge3  (cart3)    .rom  
+             cartridge4  (cart4)    .rom  
 bbcm         printer     (prin)     .prn  
              cassette    (cass)     .wav  .csw  .uef  
              floppydisk1 (flop1)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .ssd  .bbc  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
+             cartridge3  (cart3)    .rom  
+             cartridge4  (cart4)    .rom  
 bcs3         (none)
 bcs3a        (none)
 bcs3b        (none)
 bcs3c        (none)
-bebox        cdrom       (cdrm)     .chd  
-             harddisk    (hard)     .chd  .hd   
-             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-bebox2       cdrom       (cdrm)     .chd  
-             harddisk    (hard)     .chd  .hd   
-             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+bebox        harddisk1   (hard1)    .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+bebox2       harddisk1   (hard1)    .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 beehive      (none)
+berlinp      (none)
+besta88      (none)
 bestzx       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 beta         cartridge   (cart)     .bin  .rom  
-bigboard     floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+bigboard     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 bigbord2     floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+binbug       cassette    (cass)     .wav  
+             quickload   (quik)     .pgm  
 bk0010       cassette    (cass)     .wav  
 bk001001     cassette    (cass)     .wav  
 bk0010fd     cassette    (cass)     .wav  
 bk0011m      cassette    (cass)     .wav  
+bk8t         cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 blitzs       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 bmjr         cassette    (cass)     .wav  
-bml3         (none)
+bml3         floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+bml3mk2      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+bml3mk5      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 bndarc       cartridge   (cart)     .bin  
 bob85        cassette    (cass)     .wav  
-brailab4     (none)
+borisdpl     (none)
+bpl32        (none)
+br8641       (none)
+brailab4     cassette    (cass)     .wav  
+             quickload   (quik)     .htp  
+braiplus     cassette    (cass)     .wav  
+             quickload   (quik)     .htp  
+bridgec3     (none)
 bruc100      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-bullet       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             printer     (prin)     .prn  
+             cartridge2  (cart2)    .mx1  .rom  
 busicom      (none)
-bw12         printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-bw14         printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+bw12         floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+bw14         floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
 bw2          printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk  (flop)     .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 bw230        printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-bx256hp      quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+bx256hp      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
 byte         snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 c10          (none)
-c116         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c116c        quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+c116         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c116v        quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+c128         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128_de      cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128_se      cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128cr       cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128d        cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128d81      cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .d81  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+c128dcr      cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128dcr_de   cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128dcr_se   cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128dcrp     cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128dp       cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c128p        cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  
+             cartridge2  (cart2)    .bin  .rom  
+             floppydisk  (flop)     .g64  .g71  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+c16          cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c128         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128cr       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128d        quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128d81      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge1  (cart1)    .crt  .80   
-             floppydisk  (flop)     .d81  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c128dcr      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge1  (cart1)    .crt  .80   
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c128dpr      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128drde     quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128drit     quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128drsw     quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128fra      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128ger      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128nor      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c128sfi      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .d71  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c16          quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c16c         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+c16_hu       cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c16hun       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c16sid       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c16v         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+c16p         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
 c1p          cassette    (cass)     .wav  
 c1pmf        cassette    (cass)     .wav  
              floppydisk  (flop)     .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-c232         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c264         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c2717        cassette    (cass)     .wav  .pmd  
-c2717pmd     cassette    (cass)     .wav  .pmd  
-c364         quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-c386sx16     printer1    (prin1)    .prn  
+c232         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+c264         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+c2717        cassette    (cass)     .wav  .pmd  .tap  .ptp  
+c2717pmd     cassette    (cass)     .wav  .pmd  .tap  .ptp  
+c386sx16     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-c64          quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+c64          cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64c         quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64_jp       cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64cpal      quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64_se       cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64csfi      quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64c         cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64dtv       quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64c_es      cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64c_se      cassette    (cass)     .wav  .tap  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64cp        cassette    (cass)     .wav  .tap  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64dtv       (none)
 c64dx        quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .crt  .80   
-c64g         quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+c64g         cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64gs        cartridge1  (cart1)    .crt  .80   
-c64jpn       quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64gs        cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+c64p         cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64pal       quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-c64swe       quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
 c65          quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .crt  .80   
 c80          cassette    (cass)     .wav  
+c8002        (none)
+c900         (none)
 canonv10     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 canonv20     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 carmarty     floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 casloopy     cartridge   (cart)     .ic1  .bin  
 cat          (none)
-cbm30        cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm30b       cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm30nor     cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm4064      quickload   (quik)     .p00  .prg  .t64  
+cbm3008      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-cbm40b       cassette1   (cass1)    .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm40n       cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+cbm3016      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm40o       cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+cbm3032      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm40ob      cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+cbm3032b     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm610       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm620       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm620hu     quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm710       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm720       quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm720se     quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-cbm80        cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+cbm4016      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm80ger     cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm4032      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm80hun     cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm4032b     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm80swe     cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm610       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm620       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm620_hu    floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm710       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm720       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm720_de    floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm720_se    floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm730       floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  .t64  
+cbm8032      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm8296      cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8032_de   floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-cbm8296d     cassette1   (cass1)    .wav  .tap  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8032_se   floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8096      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8296      floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8296d     floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8296d_de  floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8296ed    floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+cbm8296gd    floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
 cc10         (none)
-ccs2422      (none)
+ccmk1        (none)
+ccmk2        (none)
+ccs2422      floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ccs2810      (none)
-cd2650       (none)
-cd32         cdrom       (cdrm)     .chd  
-cdimono1     cdrom       (cdrm)     .chd  
+ccs300       (none)
+cd2650       quickload   (quik)     .pgm  
+             cassette    (cass)     .wav  
+cd32         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+cdc721       (none)
+cdimono1     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 cdtv         printer     (prin)     .prn  
-             floppydisk1 (flop1)    .adf  
-             cdrom       (cdrm)     .chd  
-cdx          (none)
+             floppydisk  (flop)     .adf  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+cdx          cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 cf1200       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cf2000       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cf2700       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+cf2700g      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cf3000       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cf3300       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cfx9850      (none)
 cgc7900      (none)
 cgenie       cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 cgenienz     cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .cgd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 channelf     cartridge   (cart)     .bin  .chf  
 channlf2     cartridge   (cart)     .bin  .chf  
 chaos        (none)
 chessmst     (none)
+chesstrv     (none)
 cip01        snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -601,11 +986,12 @@ cip03        snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 clcd         (none)
-cm1200       cartridge   (cart)     .st2  .bin  
+cm1200       cartridge   (cart)     .st2  .bin  .rom  
 cm1800       (none)
-cmdpc30      printer1    (prin1)    .prn  
+cm32l        (none)
+cmdpc30      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 cobra80      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -614,44 +1000,63 @@ cobrasp      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-coco         printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             cassette    (cass)     .wav  .cas  
+coco         cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
              cartridge   (cart)     .ccc  .rom  
-coco2        printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             cassette    (cass)     .wav  .cas  
+coco2        cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-coco2b       printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
+coco2b       cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-coco3        printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             harddisk    (hard)     .vhd  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
+coco3        cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-coco3h       printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             harddisk    (hard)     .vhd  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
+coco3h       cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-coco3p       printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             harddisk    (hard)     .vhd  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
+coco3p       cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-cocoe        printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
+cocoe        cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .vhd  
+             harddisk2   (hard2)    .vhd  
 codata       (none)
 coleco       cartridge   (cart)     .rom  .col  .bin  
 colecoa      cartridge   (cart)     .rom  .col  .bin  
@@ -660,74 +1065,103 @@ compani1     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
+compc1       printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 compis       printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  .dsk  .img  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  .dsk  .img  
 compis2      printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  .dsk  .img  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  .dsk  .img  
 comquest     (none)
 comx35n      quickload   (quik)     .comx 
              cassette    (cass)     .wav  
-             printer     (prin)     .prn  
-             floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 comx35p      quickload   (quik)     .comx 
              cassette    (cass)     .wav  
-             printer     (prin)     .prn  
-             floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-concept      harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+concept      floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             harddisk    (hard)     .chd  .hd   
+copera       cartridge   (cart)     .bin  .md   
+cortex       (none)
 cosmicos     quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-cp400        printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             quickload   (quik)     .bin  
-             cassette    (cass)     .wav  .cas  
+cp1          cassette    (cass)     .wav  
+             quickload   (quik)     .obj  
+cp400        cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 cpc300       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cpc300e      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cpc400       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cpc400s      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cpc464       printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 cpc464p      printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .cpr  .bin  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 cpc6128      printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 cpc6128f     printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 cpc6128p     printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .cpr  .bin  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 cpc6128s     printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 cpc664       printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 craft        (none)
 crvisio2     cassette    (cass)     .wav  
              printer     (prin)     .prn  
@@ -738,56 +1172,80 @@ crvisioj     cassette    (cass)     .wav
 crvision     cassette    (cass)     .wav  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
-ct486        printer1    (prin1)    .prn  
+csc          (none)
+ct386sx      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-cx3000tc     quickload   (quik)     .tvc  
+ct486        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+cvicny       (none)
+cx3000tc     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 cx5m         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cx5m128      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cx5m2        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cx7m         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 cx7m128      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-cybikov1     (none)
-cybikov2     (none)
-cybikoxt     (none)
+             cartridge2  (cart2)    .mx1  .rom  
+cybikov1     quickload   (quik)     .bin  .nv   
+cybikov2     quickload   (quik)     .bin  .nv   
+cybikoxt     quickload   (quik)     .bin  .nv   
 czk80        (none)
 czz50        cartridge   (cart)     .rom  .col  .bin  
-d64plus      printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             cassette    (cass)     .wav  .cas  
+d110         (none)
+d64plus      cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 d6800        cassette    (cass)     .wav  
+             quickload   (quik)     .bin  .c8   .ch8  
 d6809        (none)
+dagz80       (none)
 dai          cassette    (cass)     .wav  
 dallas       (none)
 dallas16     (none)
 dallas32     (none)
-database     quickload   (quik)     .tvc  
+database     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 dator3k      (none)
-dc           cdrom       (cdrm)     .chd  
-dcdev        cdrom       (cdrm)     .chd  
-dceu         cdrom       (cdrm)     .chd  
-dcjp         cdrom       (cdrm)     .chd  
+dc           cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+dcdev        cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+dceu         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+dcjp         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+dcprt        cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 dct11em      (none)
 dectalk      (none)
-dendy        cartridge   (cart)     .nes  .unf  
+dendy        cartridge   (cart)     .nes  .unf  .unif 
+dg680        cassette    (cass)     .wav  
 dgama87      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -800,14 +1258,28 @@ dgama89      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-dgnalpha     printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             cassette    (cass)     .wav  .cas  
+dgnalpha     cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 dgnbeta      floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 dgone        printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+diablo68     (none)
 didakm91     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
+             quickload   (quik)     .raw  .scr  
+             cassette    (cass)     .wav  .tzx  .tap  .blk  
+             cartridge   (cart)     .rom  
+didakm92     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
@@ -823,85 +1295,196 @@ didaktk      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-dim68k       (none)
+digel804     (none)
+dim68k       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 dina         cartridge   (cart)     .rom  .col  .bin  
 dm500        (none)
 dm5620       (none)
 dm7000       (none)
 dms5000      (none)
 dms86        (none)
-dolphin      (none)
+dmv          floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+dn3000       floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dn3000_19i   floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dn3500       floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dn3500_19i   floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dn5500       floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dn5500_19i   floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dolphunk     (none)
 dpc100       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 dpc180       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 dpc200       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-dragon32     printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             cassette    (cass)     .wav  .cas  
+             cartridge2  (cart2)    .mx1  .rom  
+dps1         (none)
+dragon200    cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-dragon64     printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             cassette    (cass)     .wav  .cas  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+dragon32     cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-drpcjr       cartridge   (cart)     .nes  .unf  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+dragon64     cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
+             floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+drpcjr       cartridge   (cart)     .nes  .unf  .unif 
              floppydisk  (flop)     .fds  
+             cassette    (cass)     .wav  
+drwrt100     (none)
 drwrt200     (none)
 drwrt400     (none)
+drwrt450     (none)
 ds2          quickload   (quik)     .rex  .ds2  
+dsb46        (none)
+dsp3000      floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dsp3500      floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
+dsp5500      floppydisk  (flop)     .afd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             disk1       (disk1)    .awd  
+             disk2       (disk2)    .awd  
+             ctape       (ct)       .act  
 dual68       (none)
+dx64         cassette    (cass)     .wav  .tap  
+             floppydisk1 (flop1)    .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
 dynavisn     cartridge   (cart)     .bin  
-e01          floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-e01s         floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 eacc         (none)
 ec1840       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ec1841       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+ec1841       printer     (prin)     .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ec1845       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ec1849       printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+ec1849       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 ec65         (none)
 ec65k        (none)
-edu64        quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
+edu64        cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-ehx20        (none)
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+ehx20        cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+ehx20e       cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 einst256     printer     (prin)     .prn  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 einstei2     printer     (prin)     .prn  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 einstein     printer     (prin)     .prn  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ekusera      cartridge   (cart)     .bin  
 electron     cassette    (cass)     .wav  .uef  
+             cartridge   (cart)     .bin  
 elekscmp     (none)
-elektor      (none)
+elektor      quickload   (quik)     .pgm  .tvc  
+             cartridge   (cart)     .rom  .bin  
+             cassette    (cass)     .wav  
 elf2         cassette    (cass)     .wav  
              quickload   (quik)     .bin  
-elwro800     printer     (prin)     .prn  
+elwro800     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-ep128        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ep64         floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+enmirage     floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+ep128        printer     (prin)     .prn  
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+             cartridge   (cart)     .rom  .bin  
+ep64         printer     (prin)     .prn  
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+             cartridge   (cart)     .rom  .bin  
+ep804        (none)
+eps          midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 erik         cassette    (cass)     .wav  .rks  
-             floppydisk1 (flop1)    .odi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 es210_es     (none)
-esq1         (none)
+esq1         midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+esqm         midiin      (min)      .mid  
+             midiout     (mout)     .mid  
 et3400       (none)
 eti660       cassette    (cass)     .wav  
 europc       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+evmbug       (none)
 ex800        (none)
 exeltel      (none)
 exl100       (none)
@@ -909,307 +1492,545 @@ exp85        cassette    (cass)     .wav
 expert10     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 expert11     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 expert13     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 expert20     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+expert3i     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+expert3t     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+expertac     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 expertdp     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+expertdx     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 expertpl     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-f1392        quickload   (quik)     .tvc  
+             cartridge2  (cart2)    .mx1  .rom  
+f1           printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+f10          printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+f1392        quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-falcon30     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+f1e          printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+f2           printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+falcon30     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-falcon40     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+falcon40     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-fami_key     cartridge   (cart)     .nes  .unf  
+famicom      cartridge   (cart)     .nes  .unf  .unif 
              floppydisk  (flop)     .fds  
-famicom      cartridge   (cart)     .nes  .unf  
+             cassette    (cass)     .wav  
+famitwin     cartridge   (cart)     .nes  .unf  .unif 
              floppydisk  (flop)     .fds  
-famitwin     cartridge   (cart)     .nes  .unf  
-             floppydisk  (flop)     .fds  
+             cassette    (cass)     .wav  
 fellow       printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
-fforce2      quickload   (quik)     .tvc  
+             floppydisk2 (flop2)    .dsk  
+fforce2      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-ficpio2      printer1    (prin1)    .prn  
+ficpio2      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ficvt503     printer1    (prin1)    .prn  
-             harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer     (prin)     .prn  
+ficvt503     harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
 fk1          (none)
 fm11         cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fm16beta     cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fm7          cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fm7740sx     cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fm77av       cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-fm7a         cassette    (cass)     .wav  .t77  
-             printer     (prin)     .prn  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fm8          cassette    (cass)     .wav  .t77  
              printer     (prin)     .prn  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+fmnew7       cassette    (cass)     .wav  .t77  
+             printer     (prin)     .prn  
+             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 fmtmarty     floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fmtowns      floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fmtownsa     floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fmtownshr    floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fmtownssj    floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fmtownsux    floppydisk1 (flop1)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cdrom       (cdrm)     .chd  
+             floppydisk2 (flop2)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .bin  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
 fnvision     cassette    (cass)     .wav  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
+fp           floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
 fp1100       (none)
+fp200        (none)
 fp6000       (none)
 fs1300       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs4000       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs4500       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs4600       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs4700       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs5000       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fs5500       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1a        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1f        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1fm       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1fx       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+fsa1gt       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1mk2      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+fsa1st       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1wsx      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1wx       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 fsa1wxa      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+ftsserv      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
 g7400        cartridge   (cart)     .bin  .rom  
 galaxy       snapshot    (dump)     .gal  
              cassette    (cass)     .wav  .gtp  
 galaxyp      snapshot    (dump)     .gal  
              cassette    (cass)     .wav  .gtp  
 galeb        (none)
-gameboy      cartridge   (cart)     .gb   .gmb  .cgb  .gbc  .sgb  .bin  
+gameboy      cartridge   (cart)     .bin  .gb   .gbc  
 gamecom      cartridge1  (cart1)    .bin  .tgc  
-gamegeaj     cartridge   (cart)     .gg   .bin  
-gamegear     cartridge   (cart)     .gg   .bin  
+             cartridge2  (cart2)    .bin  .tgc  
+gamegeaj     cartridge   (cart)     .bin  .gg   
+gamegear     cartridge   (cart)     .bin  .gg   
 gamepock     cartridge   (cart)     .bin  
 gba          cartridge   (cart)     .gba  .bin  
-gbcolor      cartridge   (cart)     .gb   .gmb  .cgb  .gbc  .sgb  .bin  
-gblight      cartridge   (cart)     .gb   .gmb  .cgb  .gbc  .sgb  .bin  
-gbpocket     cartridge   (cart)     .gb   .gmb  .cgb  .gbc  .sgb  .bin  
+gbcolor      cartridge   (cart)     .bin  .gb   .gbc  
+gblight      cartridge   (cart)     .bin  .gb   .gbc  
+gbpocket     cartridge   (cart)     .bin  .gb   .gbc  
+gen32        (none)
+gen32_41     (none)
+gen32_oc     (none)
 genesis      cartridge   (cart)     .smd  .bin  .md   .gen  
-geneve       memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
-             floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+geneve       floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-gensvp       cartridge   (cart)     .smd  .bin  .md   .gen  
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
 gizmondo     (none)
+gl8008cx     (none)
 glasgow      (none)
 gmaster      cartridge   (cart)     .bin  
 gp2x         (none)
 gp32         memcard     (memc)     .smc  
+grfd2301     (none)
 gsfc200      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 gx4000       cartridge   (cart)     .cpr  .bin  
 h19          (none)
-h8           (none)
+h8           cassette    (cass)     .wav  
 h89          (none)
 hanihac      cartridge   (cart)     .bin  
+harriet      (none)
 hb10p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb201        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb201p       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb20p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb501p       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb55d        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb55p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb75d        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hb75p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf1         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf12        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf1xd       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf1xdj      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf1xdm2     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf1xv       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+hbf5         printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf500       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf500p      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf700d      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf700f      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf700p      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf700s      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf900       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf900a      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf9p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+hbf9pr       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbf9s        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+hbf9sp       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbg900ap     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hbg900p      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hc128        snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -1238,185 +2059,296 @@ hec2hr       cassette    (cass)     .wav  .k7   .cin  .for
              printer     (prin)     .prn  
 hec2hrp      cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
-hec2hrx      floppydisk1 (flop1)    .HE2  .HE7  .HE8  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+hec2hrx      floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
-hec2mx40     floppydisk1 (flop1)    .HE2  .HE7  .HE8  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+hec2mdhrx    floppydisk  (flop)     .HMD  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
-hec2mx80     floppydisk1 (flop1)    .HE2  .HE7  .HE8  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+hec2mx40     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  .k7   .cin  .for  
+             printer     (prin)     .prn  
+hec2mx80     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
 hector1      cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
-hisaturn     cdrom       (cdrm)     .chd  
+hisaturn     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              cartridge   (cart)     .bin  
-hmg1292      quickload   (quik)     .tvc  
+hmg1292      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-hmg1392      quickload   (quik)     .tvc  
+hmg1392      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 hmg2650      cartridge   (cart)     .bin  
 hobby        cassette    (cass)     .wav  .tap  .cas  
-homelab2     (none)
-homelab3     (none)
-homelab4     (none)
+homelab2     cassette    (cass)     .wav  
+             quickload   (quik)     .htp  
+homelab3     cassette    (cass)     .wav  
+             quickload   (quik)     .htp  
+homelab4     cassette    (cass)     .wav  
+             quickload   (quik)     .htp  
 homez80      (none)
-horizdd      (none)
-horizsd      (none)
 hotbi13b     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hotbi13p     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hotbit11     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hotbit12     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hotbit20     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hp16500b     (none)
-hp38g        Xmodem      (x)        .     
-             Kermit      (k)        .     
-hp39g        Xmodem      (x)        .     
-             Kermit      (k)        .     
-hp48g        Xmodem      (x)        .     
-             Kermit      (k)        .     
-hp48gp       Xmodem      (x)        .     
-             Kermit      (k)        .     
+hp38g        (none)
+hp39g        (none)
+hp48g        (none)
+hp48gp       (none)
 hp48gx       port1       (p1)       .crd  
-             Xmodem      (x)        .     
-             Kermit      (k)        .     
-hp48s        Kermit      (k)        .     
+             port2       (p2)       .crd  
+hp48s        (none)
 hp48sx       port1       (p1)       .crd  
-             Kermit      (k)        .     
-hp49g        Xmodem      (x)        .     
-             Kermit      (k)        .     
+             port2       (p2)       .crd  
+hp49g        (none)
 hp49gp       (none)
 hp9816       (none)
-hr16         (none)
-hr16b        (none)
+hpz80unk     (none)
+hr16         cassette    (cass)     .wav  
+hr16b        cassette    (cass)     .wav  
+hs           (none)
 ht108064     cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 ht1080z      cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 ht1080z2     cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
-ht68k        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ht68k        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 hx10         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hx10s        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hx20         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hx23         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 hx23f        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-i8530286     printer1    (prin1)    .prn  
+             cartridge2  (cart2)    .mx1  .rom  
+hxhdci2k     (none)
+i8530286     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-i8555081     printer1    (prin1)    .prn  
+i8530h31     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+i8535043     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+i8550021     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+i8550061     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+i8555081     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+i8580071     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+i8580111     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
 ibm5140      cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
 ibm5150      cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
 ibm5155      cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-ibm5160      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+ibm5160      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-ibm5162      printer1    (prin1)    .prn  
+             harddisk2   (hard2)    .chd  .hd   
+ibm5162      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ibm5170      printer1    (prin1)    .prn  
+ibm5170      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-ibm5170a     printer1    (prin1)    .prn  
+ibm5170a     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 ibm5550      printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+ibm6580      (none)
 ibmpcjr      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
              cassette    (cass)     .wav  
-             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge1  (cart1)    .jrc  
+             cartridge2  (cart2)    .jrc  
 ibmpcjx      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
              cassette    (cass)     .wav  
-             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge1  (cart1)    .jrc  
+             cartridge2  (cart2)    .jrc  
+ibmps1es     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+ics8080      (none)
+ie15         bitbngr     (bitb)     .     
 if800        (none)
 imds         (none)
 impuls03     cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
+imsai        (none)
 indiana      (none)
 ingtelma     cartridge   (cart)     .bin  .chf  
-instruct     (none)
+instruct     quickload   (quik)     .pgm  
+             cassette    (cass)     .wav  
 interact     cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
 intervsn     cartridge   (cart)     .bin  
 intmpt03     cartridge   (cart)     .bin  
 intv         cartridge   (cart)     .int  .rom  .bin  .itv  
+intv2        cartridge   (cart)     .int  .rom  .bin  .itv  
+intvecs      cartridge   (cart)     .int  .rom  .bin  .itv  
 intvkbd      cartridge1  (cart1)    .int  .rom  .bin  .itv  
+             cartridge2  (cart2)    .int  .rom  .bin  .itv  
 intvsrs      cartridge   (cart)     .int  .rom  .bin  .itv  
 inves        snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-ip204415     cdrom       (cdrm)     .chd  
+ip204415     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 ip224613     printer     (prin)     .prn  
-             cdrom       (cdrm)     .chd  
              harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 ip225015     printer     (prin)     .prn  
-             cdrom       (cdrm)     .chd  
              harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 ip244415     printer     (prin)     .prn  
-             cdrom       (cdrm)     .chd  
              harddisk    (hard)     .chd  .hd   
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 ipb          (none)
 ipc          (none)
 ipds         (none)
-iq151        (none)
+iq128        cartridge   (cart)     .bin  
+iq128_fr     cartridge   (cart)     .bin  
+iq151        cassette    (cass)     .wav  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+             cartridge4  (cart4)    .bin  .rom  
+             cartridge5  (cart5)    .bin  .rom  
+iqtv512      cartridge   (cart)     .bin  
 irisha       (none)
 isbc286      (none)
 isbc2861     (none)
 isbc86       (none)
 iskr1030m    printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 iskr1031     printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+iskr3104     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 itmcmtp3     cartridge   (cart)     .bin  
+itt3030      (none)
 itttelma     cartridge   (cart)     .bin  .chf  
 ivelultr     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 ixl2000      cartridge   (cart)     .bin  
+jade         (none)
 jaguar       quickload   (quik)     .abs  .bin  .cof  .jag  .prg  
              cartridge   (cart)     .j64  .rom  
 jaguarcd     quickload   (quik)     .abs  .bin  .cof  .jag  .prg  
@@ -1425,6 +2357,7 @@ jet          snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
+jonos        (none)
 jopac        cartridge   (cart)     .bin  .rom  
 jr100        cassette    (cass)     .wav  
              quickload   (quik)     .prg  
@@ -1440,115 +2373,161 @@ jtces40      cassette    (cass)     .wav
              printer     (prin)     .prn  
 jtces88      cassette    (cass)     .wav  
              printer     (prin)     .prn  
+juicebox     memcard     (memc)     .smc  
 junior       (none)
+jupace       cassette    (cass)     .wav  .tap  
+             snapshot    (dump)     .ace  
+             printer     (prin)     .prn  
 jupiter2     (none)
 jupiter3     (none)
 jvchc7gb     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 k1003        (none)
+k286i        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 k8915        (none)
 kay1024      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 kaypro10     quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kaypro2x     quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kaypro4      quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kaypro4a     quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kaypro4p88   quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kayproii     quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kc85         printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .rom  .bin  
-kc85_111     (none)
+kc85_111     cassette    (cass)     .wav  
 kc85_2       quickload   (quik)     .kcc  
-             cassette    (cass)     .wav  
+             cassette    (cass)     .wav  .kcc  .kcb  .tap  .853  .854  .855  .tp2  .kcm  .sss  
+             cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
 kc85_3       quickload   (quik)     .kcc  
-             cassette    (cass)     .wav  
+             cassette    (cass)     .wav  .kcc  .kcb  .tap  .853  .854  .855  .tp2  .kcm  .sss  
+             cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
 kc85_4       quickload   (quik)     .kcc  
-             cassette    (cass)     .wav  
-kc85_4d      quickload   (quik)     .kcc  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .kcc  .kcb  .tap  .853  .854  .855  .tp2  .kcm  .sss  
+             cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
 kc85_5       quickload   (quik)     .kcc  
-             cassette    (cass)     .wav  
-kc87_10      (none)
-kc87_11      (none)
-kc87_20      (none)
-kc87_21      (none)
+             cassette    (cass)     .wav  .kcc  .kcb  .tap  .853  .854  .855  .tp2  .kcm  .sss  
+             cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
+kc87_10      cassette    (cass)     .wav  
+kc87_11      cassette    (cass)     .wav  
+kc87_20      cassette    (cass)     .wav  
+kc87_21      cassette    (cass)     .wav  
 kccomp       printer     (prin)     .prn  
              snapshot    (dump)     .sna  
              cassette    (cass)     .wav  .cdt  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kim1         cassette    (cass)     .wav  .kim  .kim1 
-kontiki      floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+konin        (none)
+kontiki      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 kontur       cassette    (cass)     .wav  
              floppydisk1 (flop1)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 korvet       cassette    (cass)     .wav  
              floppydisk1 (flop1)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 kr03         cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 kramermc     (none)
-krvnjvtv     quickload   (quik)     .tvc  
+krista2      cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .emr  
+kristall2    cassette    (cass)     .wav  .rk8  
+krvnjvtv     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
+kt76         midiin      (min)      .mid  
+             midiout     (mout)     .mid  
 lambda       cassette    (cass)     .wav  .p    .81   
 las110de     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
-las128ex     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
+             floppydisk2 (flop2)    .dsk  
+las128ex     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 las210de     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 las3000      floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 laser110     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
-laser128     floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
+             floppydisk2 (flop2)    .dsk  
+laser128     cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 laser200     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 laser210     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 laser310     printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 laser310h    printer     (prin)     .prn  
              snapshot    (dump)     .vz   
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 laser350     cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
@@ -1558,247 +2537,460 @@ laser500     cassette    (cass)     .wav  .cas
 laser700     cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-laseract     (none)
-laseractj    (none)
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+laseract     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+laseractj    cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 lc80         cassette    (cass)     .wav  
 lc80_2       cassette    (cass)     .wav  
 lcmate2      (none)
 leonardo     cartridge   (cart)     .bin  
+lft1230      (none)
+lft1510      (none)
 lik          cassette    (cass)     .wav  .rks  
-lisa         floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-lisa2        floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-lisa210      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+lisa         floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+lisa2        floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+lisa210      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 llc1         (none)
 llc2         (none)
-lnsy1392     quickload   (quik)     .tvc  
+lnsy1392     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 lnw80        cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
+lola8a       cassette    (cass)     .wav  
+lond020      (none)
+lond030      (none)
 luxorvec     cartridge   (cart)     .bin  .chf  
 luxorves     cartridge   (cart)     .bin  .chf  
 lvision      cartridge   (cart)     .bin  
 lviv         snapshot    (dump)     .sav  
-             cassette    (cass)     .wav  .lvt  
+             cassette    (cass)     .wav  .lvt  .lvr  .lv0  .lv1  .lv2  .lv3  
 lx800        (none)
 lynx         quickload   (quik)     .o    
              cartridge   (cart)     .lnx  .lyx  
 lynx128k     (none)
 lynx48k      (none)
 lynx96k      (none)
+lyon16       (none)
+lyon32       (none)
+lzcolor64    cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
 m10          printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .rom  .bin  
-m20          (none)
+m20          floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 m24          printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 m240         printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-m40          (none)
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+m40          floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 m5           printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
-             floppydisk  (flop)     .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk  (flop)     .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  .rom  
 m5p          printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
-             floppydisk  (flop)     .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk  (flop)     .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  .rom  
-m82          cartridge   (cart)     .nes  .unf  
+m79152pc     (none)
+m82          cartridge   (cart)     .nes  .unf  .unif 
 m86rk        cassette    (cass)     .wav  .rkm  
-mac128k      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-mac2fdhd     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+mac128k      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+mac2fdhd     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+mac512k      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+mac512ke     floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maccclas     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macclas2     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macclasc     floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-mac512k      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-mac512ke     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-macclas2     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+macii        harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciici      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciicx      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciifx      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciihmu     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciisi      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciivi      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciivx      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maciix       harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maclc        harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maclc2       harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maclc3       harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+maclc520     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb100     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb140     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb145     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb145b    harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb160     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb170     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb180     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macpb180c    harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macplus      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-macclasc     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+macprtb      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macqd700     floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-macii        floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+macse        floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-maciici      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+macse30      harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+macsefd      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-maciicx      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-maciisi      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-maciix       floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-maclc        floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-maclc2       floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-maclc3       floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macpb100     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macplus      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macprtb      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macse        floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macse30      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macsefd      floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-macxl        floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+macxl        floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 magic6       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 manager      cassette    (cass)     .wav  
-             floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
-mato         cassette    (cass)     .wav  .pmd  
-max          quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .crt  .e0   .f0   
+mato         cassette    (cass)     .wav  .pmd  .tap  .ptp  
+mbc16        printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+mbc200       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 mbc55x       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 mbee         quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbee128      quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mbee256      quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mbee56       quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mbee64       quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .ss80 .ds40 .ds80 .ds82 .ds84 .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mbeeic       quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeepc       quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeepc85     quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeepc85b    quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeepc85s    quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeeppc      quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mbeett       quickload1  (quik1)    .mwb  .com  
+             quickload2  (quik2)    .bin  
              printer     (prin)     .prn  
              cassette    (cass)     .wav  
 mc10         cassette    (cass)     .wav  .cas  
              printer     (prin)     .prn  
 mc1000       cassette    (cass)     .wav  
              printer     (prin)     .prn  
-mc1502       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+mc1502       cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mc1702       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mc7105       (none)
 mc8020       (none)
 mc8030       (none)
 mccpm        (none)
-md2          floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-md3          floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-megacd       cdrom       (cdrm)     .chd  
-megacd2      cdrom       (cdrm)     .chd  
-megacd2j     cdrom       (cdrm)     .chd  
-megacda      cdrom       (cdrm)     .chd  
-megacdj      cdrom       (cdrm)     .chd  
+md2          floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+md3          floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+megacd       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+megacd2      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+megacd2j     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+megacda      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+megacdj      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 megadrij     cartridge   (cart)     .smd  .bin  .md   .gen  
 megadriv     cartridge   (cart)     .smd  .bin  .md   .gen  
 megaduck     cartridge   (cart)     .bin  
-megapc       printer1    (prin1)    .prn  
+megaiv       (none)
+megapc       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-megapcpl     printer1    (prin1)    .prn  
+             printer     (prin)     .prn  
+megapcpl     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-megast       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              printer     (prin)     .prn  
+megast       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megast_de    floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megast_de    floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megast_fr    floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megast_fr    floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megast_se    floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megast_se    floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megast_sg    floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megast_sg    floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megast_uk    floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megast_uk    floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste      floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste      floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_de   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_de   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_es   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_es   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_fr   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_fr   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_it   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_it   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_se   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_se   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-megaste_uk   floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+megaste_uk   floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
 mekd2        cassette    (cass)     .wav  
              cartridge   (cart)     .d2   
+meritum      cassette    (cass)     .wav  .cas  
+             quickload   (quik)     .cmd  
+             floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer     (prin)     .prn  
+meritum_net  cassette    (cass)     .wav  .cas  
+             quickload   (quik)     .cmd  
+             floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer     (prin)     .prn  
+merlin       (none)
 mes          (none)
+mice         (none)
+microkit     (none)
 micronic     (none)
 microtan     snapshot    (dump)     .m65  
              quickload   (quik)     .hex  
              cassette    (cass)     .wav  
+microvsn     cartridge   (cart)     .bin  
 mikro80      cassette    (cass)     .wav  .rk8  
 mikrolab     (none)
 mikron2      cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 mikrosha     cassette    (cass)     .wav  .rkm  
 milano       (none)
-mirage       floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+mini2440     (none)
+misterx      cartridge   (cart)     .bin  
 mistrum      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 mits680b     (none)
-mk1          (none)
 mk14         (none)
-mk2          (none)
+mk82         floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+mk83         floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mk85         (none)
 mk88         printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mk90         (none)
 mlf80        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 mlfx1        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-mm1m6        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-mm1m7        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .mx1  .rom  
+mlg30        printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+mm1m6        floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+mm1m7        floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mm2          (none)
 mm4          (none)
 mm5          (none)
@@ -1806,180 +2998,357 @@ mm50         (none)
 mm5tk        (none)
 mmd1         (none)
 mmd2         (none)
-mmf9000s     cassette1   (cass1)    .wav  .tap  
+mmf9000      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+mmf9000_se   floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
 mo5          printer     (prin)     .prn  
              cassette    (cass)     .wav  .k5   .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m5   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 mo5e         printer     (prin)     .prn  
              cassette    (cass)     .wav  .k5   .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m5   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 mo5nr        cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m5   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
-mo6          cassette    (cass)     .wav  .k7   
+mo6          cassette    (cass)     .wav  .k5   .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m5   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
 mod8         (none)
+modellot     (none)
+monteciv     (none)
+mpc10        printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 mpc100       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+mpc2300      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+mpc25fd      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+mpc64        printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 mpf1         cassette    (cass)     .wav  
 mpf1b        cassette    (cass)     .wav  
 mpf1p        cassette    (cass)     .wav  
 mprof3       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
-mpt02        cartridge   (cart)     .st2  .bin  
-mpt02h       cartridge   (cart)     .st2  .bin  
-mpt05        quickload   (quik)     .tvc  
+mpt02        cartridge   (cart)     .st2  .bin  .rom  
+mpt02h       cartridge   (cart)     .st2  .bin  .rom  
+mpt05        quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-mpu1000      quickload   (quik)     .tvc  
+mpu1000      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-mpu2000      quickload   (quik)     .tvc  
+mpu2000      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-mpz80        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+mpz80        floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 mratlus      cartridge   (cart)     .bin  
+mrrack       (none)
+ms0515       floppydisk  (flop)     .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ms9540       (none)
 msbc1        (none)
+mstation     (none)
 msx          printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 msx2         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 msx2p        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-mtc9016      cartridge   (cart)     .st2  .bin  
+             cartridge2  (cart2)    .mx1  .rom  
+mt32         (none)
+mtc9016      cartridge   (cart)     .st2  .bin  .rom  
 mtx500       printer     (prin)     .prn  
-             snapshot    (dump)     .mtb  
+             snapshot    (dump)     .mtx  
              cassette    (cass)     .wav  
 mtx512       printer     (prin)     .prn  
-             snapshot    (dump)     .mtb  
+             snapshot    (dump)     .mtx  
              cassette    (cass)     .wav  
+mu100        (none)
 multi16      (none)
 multi8       (none)
-multmega     (none)
+multmega     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+mx1600       cassette    (cass)     .wav  .cas  
+             bitbngr     (bitb)     .     
+             cartridge   (cart)     .ccc  .rom  
+mx64         printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 myb3k        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 mycom        cassette    (cass)     .wav  
-mz1500       cassette    (cass)     .wav  .m12  .mzf  
+             floppydisk1 (flop1)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+mz1500       cassette    (cass)     .wav  .m12  .mzf  .mzt  
              printer     (prin)     .prn  
 mz2000       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .m12  .mzf  .mzt  
 mz2200       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .m12  .mzf  .mzt  
 mz2500       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 mz2520       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-mz6500       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-mz700        cassette    (cass)     .wav  .m12  .mzf  
-mz700j       cassette    (cass)     .wav  .m12  .mzf  
-mz800        cassette    (cass)     .wav  .m12  .mzf  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+mz3500       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+mz6500       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+mz700        cassette    (cass)     .wav  .m12  .mzf  .mzt  
+mz700j       cassette    (cass)     .wav  .m12  .mzf  .mzt  
+mz800        cassette    (cass)     .wav  .m12  .mzf  .mzt  
              printer     (prin)     .prn  
 mz80a        cassette    (cass)     .wav  
 mz80b        cassette    (cass)     .wav  
 mz80k        cassette    (cass)     .wav  
 mz80kj       cassette    (cass)     .wav  
 n64          cartridge   (cart)     .v64  .z64  .rom  .n64  .bin  
+n64dd        cartridge   (cart)     .v64  .z64  .rom  .n64  .bin  
 nano         quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-nanos        floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+nanos        floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 nascom1      snapshot    (dump)     .nas  
              cassette    (cass)     .wav  
 nascom2      snapshot    (dump)     .nas  
              cassette    (cass)     .wav  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 nc100        printer     (prin)     .prn  
              cartridge   (cart)     .crd  .card 
 nc150        printer     (prin)     .prn  
              cartridge   (cart)     .crd  .card 
 nc200        cartridge   (cart)     .crd  .card 
              printer     (prin)     .prn  
-             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-neat         printer1    (prin1)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
+nd80z        (none)
+neat         floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+nectk85      (none)
 neiva        cassette    (cass)     .wav  
              floppydisk1 (flop1)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-neocd        (none)
-neocdz       (none)
-nes          cartridge   (cart)     .nes  .unf  
-nespal       cartridge   (cart)     .nes  .unf  
+             floppydisk2 (flop2)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .kdi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+neocd        cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+neocdz       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+neocdzj      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+nes          cartridge   (cart)     .nes  .unf  .unif 
+nespal       cartridge   (cart)     .nes  .unf  .unif 
 newbrain     cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 newbraina    cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 newbraineim  cassette1   (cass1)    .wav  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette2   (cass2)    .wav  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 newbrainmd   cassette1   (cass1)    .wav  
-next         floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-nextnt       floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-nexttrb      floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette2   (cass2)    .wav  
+next         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+nextct       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nextctc      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nexts        cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nexts2       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nextsc       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nextst       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+nextstc      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             harddisk    (hard)     .chd  .hd   
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ngp          cartridge   (cart)     .bin  .ngp  .npc  .ngc  
 ngpc         cartridge   (cart)     .bin  .ngp  .npc  .ngc  
 nimbus       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
              printer     (prin)     .prn  
 nms801       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8220      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8220a     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8245      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8245f     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8250      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+nms8250j     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8255      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8280      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 nms8280g     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 npc8300      printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge1  (cart1)    .rom  .bin  
+             cartridge2  (cart2)    .rom  .bin  
+nshrz        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ob68k1a      (none)
-oc2000       quickload   (quik)     .tvc  
+oc2000       quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
+octopus      (none)
 odyssey2     cartridge   (cart)     .bin  .rom  
+odyssey3     cartridge   (cart)     .bin  .rom  
 okean240     (none)
 okean240a    (none)
+okean240t    (none)
+olivm15      (none)
+olypeopl     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 omni2        quickload   (quik)     .com  .cpm  
              printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-omv1000      cartridge   (cart)     .sg   .bin  
-omv2000      cartridge   (cart)     .sg   .bin  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+omv1000      cartridge   (cart)     .bin  .sg   
+omv2000      cartridge   (cart)     .bin  .sg   
 ondrat       cassette    (cass)     .wav  
 ondrav       cassette    (cass)     .wav  
 orao         cassette    (cass)     .wav  .tap  
@@ -1988,29 +3357,56 @@ orbituvi     cartridge   (cart)     .bin
 oric1        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 orica        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 orion128     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionide     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionidm     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionms      cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionpro     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionz80     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orionzms     cassette    (cass)     .wav  .rko  
-             floppydisk1 (flop1)    .odi  .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              cartridge   (cart)     .bin  
 orizon       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
@@ -2018,16 +3414,22 @@ orizon       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              cartridge   (cart)     .rom  
 ormatu       cartridge   (cart)     .bin  
 osbexec      floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 osborne1     floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-osc1000b     quickload   (quik)     .bin  
-             cassette    (cass)     .wav  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 p112         (none)
 p2000m       (none)
 p2000t       (none)
-p500         quickload   (quik)     .p00  .prg  
-             floppydisk1 (flop1)    .d80  .d82  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .10   .20   .40   .60   
-p8000        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+p500         floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  
+p500p        floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .20   .40   .60   
+             quickload   (quik)     .p00  .prg  
+p8000        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 p8000_16     (none)
 palmiii      (none)
 palmiiic     (none)
@@ -2039,17 +3441,33 @@ palmpers     (none)
 palmpro      (none)
 palmv        (none)
 palmvx       (none)
+palmz22      (none)
 partner      cassette    (cass)     .wav  .rkp  
              floppydisk1 (flop1)    .cpm  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .cpm  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 paso1600     (none)
 pasogo       cartridge   (cart)     .bin  
 pasopia      (none)
-pasopia7     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pasopia7     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pasopia7lcd  floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pb1000       (none)
 pb2000c      cartridge1  (cart1)    .bin  
-pc           floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .bin  
+pc           floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-pc100        (none)
+             harddisk2   (hard2)    .chd  .hd   
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+pc100        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc10iii      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pc1245       (none)
 pc1250       (none)
 pc1251       (none)
@@ -2064,32 +3482,76 @@ pc1403       (none)
 pc1403h      (none)
 pc1450       (none)
 pc1500       (none)
-pc1512       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-pc1512v2     printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-pc1512v32    printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-pc1640       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+pc1512       floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+pc1512dd     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+pc1512hd10   floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+pc1512hd20   floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+pc1640       floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+pc1640dd     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+pc1640hd20   floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+pc1640hd30   floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
 pc20         printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
 pc200        printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
 pc2000       cartridge   (cart)     .bin  
 pc2086       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-pc2386       printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
+pc2386       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer     (prin)     .prn  
 pc3086       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
 pc4          (none)
+pc486mu      harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pc6001       cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .cas  .p6   
 pc6001a      cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .cas  .p6   
 pc6001mk2    cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .cas  .p6   
 pc6001sr     cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .cas  .p6   
 pc6601       cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .cas  .p6   
+pc7000       printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pc8001       printer     (prin)     .prn  
              cassette    (cass)     .wav  
 pc8001mk2    printer     (prin)     .prn  
@@ -2097,133 +3559,311 @@ pc8001mk2    printer     (prin)     .prn
 pc8201       printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge1  (cart1)    .rom  .bin  
+             cartridge2  (cart2)    .rom  .bin  
 pc8201a      printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge1  (cart1)    .rom  .bin  
+             cartridge2  (cart2)    .rom  .bin  
 pc8300       cassette    (cass)     .wav  .p    .81   
 pc8500       cartridge1  (cart1)    .rom  .bin  
-pc8801       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801fa     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801ma     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801ma2    floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mc     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mh     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mk2    floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mk2fr  floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mk2mr  floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc8801mk2sr  floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc88va       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc9801f      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc9801rs     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc9821       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc9821a      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pc9821ne     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pce          cartridge   (cart)     .pce  .bin  
-             cdrom       (cdrm)     .chd  
+             cartridge2  (cart2)    .rom  .bin  
+pc8801       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801fa     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801ma     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801ma2    floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mc     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mh     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mk2    floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mk2fr  floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mk2mr  floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc8801mk2sr  floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             cassette    (cass)     .wav  
+pc88va       floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc88va2      floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801bx2    harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801f      harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801rs     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801rx     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801ux     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9801vm     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821       harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821as     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821ce2    harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821ne     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821v13    harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821v20    harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pc9821xs     harddisk    (hard)     .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .hdm  .fdi  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pcd          printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pce          cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             cartridge   (cart)     .pce  .bin  
 pce220       serial      (serl)     .txt  .ihx  
-pcega        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+pcega        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
 pcfx         (none)
 pcfxga       (none)
 pcg850v      serial      (serl)     .txt  .ihx  
 pcherc       printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
 pcm          cassette    (cass)     .wav  
 pcmda        printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-pcw10        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+pcw10        floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pcw16        printer     (prin)     .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-pcw8256      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pcw8512      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pcw9256      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pcw9512      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pcw8256      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pcw8512      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pcw9256      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pcw9512      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pda600       (none)
 pdp1         punchtape1  (ptap1)    .tap  .rim  
+             punchtape2  (ptap2)    .tap  .rim  
              printer     (prin)     .typ  
              cylinder    (cyln)     .drm  
-pdp11qb      (none)
-pdp11ub      (none)
-pdp11ub2     (none)
+pdp11qb      floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pdp11ub      floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pdp11ub2     floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 pecom64      cassette    (cass)     .wav  
 pegasus      cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
+             cartridge3  (cart3)    .bin  
+             cartridge4  (cart4)    .bin  
+             cartridge5  (cart5)    .bin  
              cassette    (cass)     .wav  
 pegasusm     cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
+             cartridge3  (cart3)    .bin  
+             cartridge4  (cart4)    .bin  
+             cartridge5  (cart5)    .bin  
              cassette    (cass)     .wav  
+pencil2      cassette    (cass)     .wav  
+             printer     (prin)     .prn  
 pent1024     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 pentagon     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 pes          (none)
-pet2001      cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet2001b     cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet2001n     cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet40b       cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet40n       cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet40ob      cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet40on      cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .90   .a0   .b0   
-             floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pet64        quickload   (quik)     .p00  .prg  .t64  
+pet2001      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
-pet80        cassette1   (cass1)    .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pet20018     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+pet2001b     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet2001b16   floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet2001b32   floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet2001n     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet2001n16   floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet2001n32   floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+             cartridge3  (cart3)    .bin  .rom  
+pet4016      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+pet4032      floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+pet4032b     floppydisk1 (flop1)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d64  .g64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+pet64        cassette    (cass)     .wav  .tap  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+pet8032      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+phc2         printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 phc23        printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 phc25        cassette    (cass)     .wav  
              printer     (prin)     .prn  
 phc25j       cassette    (cass)     .wav  
              printer     (prin)     .prn  
+phc28        printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+phc28l       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+phc28s       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 phc35j       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-phc64        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .mx1  .rom  
+phc64        printer     (prin)     .prn  
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+             cartridge   (cart)     .rom  .bin  
 phc70fd      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 phc70fd2     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-phunsy       (none)
-pico         cartridge   (cart)     .bin  
-picoj        cartridge   (cart)     .bin  
-picou        cartridge   (cart)     .bin  
+             cartridge2  (cart2)    .mx1  .rom  
+phunsy       cassette    (cass)     .wav  
+pico         cartridge   (cart)     .bin  .md   
+picoj        cartridge   (cart)     .bin  .md   
+picou        cartridge   (cart)     .bin  .md   
 pilot1k      (none)
 pilot5k      (none)
 pimps        (none)
@@ -2231,46 +3871,55 @@ pioner       cassette    (cass)     .wav  .rks
 piopx7       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-pipbug       (none)
-pippin       cdrom       (cdrm)     .chd  
+             cartridge2  (cart2)    .mx1  .rom  
+pipbug       quickload   (quik)     .pgm  
+pippin       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 pk6128c      cassette    (cass)     .wav  
              floppydisk1 (flop1)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .emr  
 pk8002       cassette    (cass)     .wav  .tap  .cas  
 plan80       (none)
 plldium      cartridge   (cart)     .bin  
-plus4        quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-plus4c       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+plus4        cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-plus4sid     quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
-plus4v       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
-             cartridge   (cart)     .bin  .rom  .hi   .lo   
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+plus4p       cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pmac6100     floppydisk1 (flop1)    .dsk  .img  .image.dc   .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             harddisk1   (hard1)    .chd  .hd   
-pmd851       cassette    (cass)     .wav  .pmd  
-pmd852       cassette    (cass)     .wav  .pmd  
-pmd852a      cassette    (cass)     .wav  .pmd  
-pmd852b      cassette    (cass)     .wav  .pmd  
-pmd853       cassette    (cass)     .wav  .pmd  
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+pm68k        (none)
+pmac6100     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+pmd851       cassette    (cass)     .wav  .pmd  .tap  .ptp  
+pmd852       cassette    (cass)     .wav  .pmd  .tap  .ptp  
+pmd852a      cassette    (cass)     .wav  .pmd  .tap  .ptp  
+pmd852b      cassette    (cass)     .wav  .pmd  .tap  .ptp  
+pmd853       cassette    (cass)     .wav  .pmd  .tap  .ptp  
 pmi80        (none)
 pockstat     cartridge   (cart)     .gme  
 pofo         printer     (prin)     .prn  
              cartridge   (cart)     .bin  
 poisk1       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 poisk2       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pokemini     cartridge   (cart)     .min  .bin  
 polgar       (none)
+poly1        (none)
 poly88       cassette    (cass)     .wav  
              snapshot    (dump)     .img  
 poly880      cassette    (cass)     .wav  
@@ -2280,19 +3929,26 @@ polyvcg      cartridge   (cart)     .bin
 poppympt     cartridge   (cart)     .bin  
 pow3000      cassette    (cass)     .wav  .p    .81   
 pp01         (none)
-pp1292       quickload   (quik)     .tvc  
+pp1292       quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-pp1392       quickload   (quik)     .tvc  
+pp1392       quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 ppc512       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
 ppc640       printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .mfi  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .mfi  
 prav82       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
-prav8c       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-             cassette    (cass)     .wav  
-             harddisk    (hard)     .chd  .hd   
+prav8c       cassette    (cass)     .wav  
+             floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 prav8d       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
@@ -2300,6 +3956,7 @@ prav8dd      printer     (prin)     .prn
              cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 prav8m       floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette    (cass)     .wav  
 prestige     cartridge   (cart)     .bin  
 prestmpt     cartridge   (cart)     .bin  
@@ -2307,120 +3964,197 @@ primoa32     snapshot    (dump)     .pss
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primoa48     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primoa64     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primob32     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primob48     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primob64     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
+             cartridge2  (cart2)    .rom  
 primoc64     snapshot    (dump)     .pss  
              quickload   (quik)     .pp   
              cassette    (cass)     .wav  .ptp  
              cartridge1  (cart1)    .rom  
-pro128       cassette    (cass)     .wav  .k7   
+             cartridge2  (cart2)    .rom  
+pro128       cassette    (cass)     .wav  .k5   .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m5   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
-pro80        (none)
-prof180x     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pro80        cassette    (cass)     .wav  
+prof180x     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-prof181x     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+prof181x     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-prof80       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+prof80       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
 profi        snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+profweis     cartridge   (cart)     .bin  
 prose2k      (none)
 prsarcde     cartridge   (cart)     .rom  .col  .bin  
-psa          quickload   (quik)     .cpe  .exe  .psf  .psx  
-             cdrom       (cdrm)     .chd  
-pse          quickload   (quik)     .cpe  .exe  .psf  .psx  
-             cdrom       (cdrm)     .chd  
+psa          memcard1    (mc1)      .mc   
+             memcard2    (mc2)      .mc   
+             quickload   (quik)     .cpe  .exe  .psf  .psx  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+pse          memcard1    (mc1)      .mc   
+             memcard2    (mc2)      .mc   
+             quickload   (quik)     .cpe  .exe  .psf  .psx  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 psioncm      cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionla      cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionlam     cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionlz      cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionlz64    cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionlz64s   cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionp350    cartridge1  (cart1)    .opk  
+             cartridge2  (cart2)    .opk  
 psionp464    cartridge1  (cart1)    .opk  
-psj          quickload   (quik)     .cpe  .exe  .psf  .psx  
-             cdrom       (cdrm)     .chd  
-psu          quickload   (quik)     .cpe  .exe  .psf  .psx  
-             cdrom       (cdrm)     .chd  
+             cartridge2  (cart2)    .opk  
+psj          memcard1    (mc1)      .mc   
+             memcard2    (mc2)      .mc   
+             quickload   (quik)     .cpe  .exe  .psf  .psx  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+psu          memcard1    (mc1)      .mc   
+             memcard2    (mc2)      .mc   
+             quickload   (quik)     .cpe  .exe  .psf  .psx  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 pt68k4       (none)
 pv1000       cartridge   (cart)     .bin  
+pv16         printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 pv2000       cassette    (cass)     .wav  
              cartridge   (cart)     .rom  .col  .bin  
 pv9234       (none)
 px4          printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge1  (cart1)    .bin  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .bin  
 px4p         printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge1  (cart1)    .bin  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .bin  
+             cartridge3  (cart3)    .bin  
 px8          cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
              cassette    (cass)     .wav  
-pyl601       floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-pyl601a      floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+pyl601       floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+pyl601a      floppydisk1 (flop1)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 pyuuta       printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .bin  
-qc10         floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-ql           floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+pyuutajr     printer     (prin)     .prn  
+             cassette    (cass)     .wav  
+             cartridge   (cart)     .bin  
+qi600        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+qi900        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+ql           floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_de        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_de        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_dk        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_dk        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_es        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_es        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_fr        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_fr        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_gr        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_gr        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_it        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_it        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_se        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_se        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
-ql_us        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+ql_us        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
              cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
 qtsbc        (none)
@@ -2429,11 +4163,15 @@ quorum       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 quorum48     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-qx10         floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+qx10         floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 radio16      cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 radio4k      cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 radio86      cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
@@ -2441,137 +4179,230 @@ radio99      cassette    (cass)     .wav  .rk8
 radionic     cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 radioram     cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 radiorom     cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
              cartridge   (cart)     .bin  .rom  
+rainbow      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 rameses      cassette    (cass)     .wav  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
+ravens       quickload   (quik)     .pgm  
+             cassette    (cass)     .wav  
+ravens2      cassette    (cass)     .wav  
 rebel5       (none)
 rex6000      quickload   (quik)     .rex  .ds2  
 ringo470     cassette    (cass)     .wav  .p    .81   
+risc         (none)
 rk7007       cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
 rk700716     cassette    (cass)     .wav  .rk   .rkr  .gam  .g16  .pki  
+rm380z       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+robie        quickload   (quik)     .com  .cpm  
+             printer     (prin)     .prn  
+             floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 roma         (none)
 roma32       (none)
 rowtrn2k     cartridge   (cart)     .bin  
 rpc86        (none)
 rs128        printer     (prin)     .prn  
-             snapshot    (dump)     .mtb  
+             snapshot    (dump)     .mtx  
              cassette    (cass)     .wav  
 rt1715       (none)
 rt1715lc     (none)
 rt1715w      (none)
 rvoicepc     (none)
-rwtrntcs     quickload   (quik)     .tvc  
+rwtrntcs     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 rx78         cartridge   (cart)     .rom  
              cassette    (cass)     .wav  
 sabavdpl     cartridge   (cart)     .bin  .chf  
 sabavpl2     cartridge   (cart)     .bin  .chf  
 sacstate     (none)
-sage2        (none)
+sage2        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
 samcoupe     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
-             floppydisk1 (flop1)    .mgt  .dsk  .sad  .sdf  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .mgt  .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .mgt  .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 sapi1        (none)
 sapizps2     (none)
 sapizps3     (none)
-saturn       cdrom       (cdrm)     .chd  
+saturn       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              cartridge   (cart)     .bin  
-saturneu     cdrom       (cdrm)     .chd  
+saturneu     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              cartridge   (cart)     .bin  
-saturnjp     cdrom       (cdrm)     .chd  
+saturnjp     cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              cartridge   (cart)     .bin  
 savia84      (none)
 sb2m600b     cassette    (cass)     .wav  
 sbc6510      (none)
+sbrain       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 sc1          (none)
 sc2          (none)
-sc3000       cassette    (cass)     .wav  
-             cartridge   (cart)     .sg   .sc   .bin  
-sc3000h      cassette    (cass)     .wav  
-             cartridge   (cart)     .sg   .sc   .bin  
+sc3000       cassette    (cass)     .wav  .bit  
+             cartridge   (cart)     .bin  .sg   .sc   
+sc3000h      cassette    (cass)     .wav  .bit  
+             cartridge   (cart)     .bin  .sg   .sc   
 sc80         cassette    (cass)     .wav  
 scorpio      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .trd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 scv          cartridge   (cart)     .bin  
 scv_pal      cartridge   (cart)     .bin  
+sd1          midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+sd132        midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 sdk85        (none)
 sdk86        (none)
-segacd       cdrom       (cdrm)     .chd  
-segacd2      cdrom       (cdrm)     .chd  
+seattle      (none)
+segacd       cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+segacd2      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 selz80       (none)
-sf7000       floppydisk  (flop)     .sf7  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+sexpertb     (none)
+sexpertc     (none)
+sf7000       floppydisk  (flop)     .sf7  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-             cassette    (cass)     .wav  
+             cassette    (cass)     .wav  .bit  
 sfach        (none)
+sfortea      (none)
+sforteb      (none)
+sforteba     (none)
+sfortec      (none)
 sfzbch       (none)
 sfzch        (none)
-sg1000       cartridge   (cart)     .sg   .bin  
-sg1000m2     cassette    (cass)     .wav  
-             cartridge   (cart)     .sg   .sc   .bin  
-sg1000m3     cartridge   (cart)     .sms  .bin  .sg   
+sg1000       cartridge   (cart)     .bin  .sg   
+sg1000m2     cassette    (cass)     .wav  .bit  
+             cartridge   (cart)     .bin  .sg   .sc   
+sg1000m3     card        (card)     .bin  
+             cartridge   (cart)     .bin  .sms  .sg   
 sgi_ip2      (none)
 sgi_ip6      (none)
 sgx          cartridge   (cart)     .pce  .bin  
-             cdrom       (cdrm)     .chd  
+             cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 sheenhvc     cartridge   (cart)     .bin  
-shmc1200     cartridge   (cart)     .st2  .bin  
+shmc1200     cartridge   (cart)     .st2  .bin  .rom  
+sitcom       (none)
+slc1         (none)
 sm1800       (none)
 smc777       floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-sms          cartridge   (cart)     .sms  .bin  
-sms1         cartridge   (cart)     .sms  .bin  
-sms1pal      cartridge   (cart)     .sms  .bin  
-sms2kr       cartridge   (cart)     .sms  .bin  
-smsj         cartridge   (cart)     .sms  .bin  
-smspal       cartridge   (cart)     .sms  .bin  
-smssdisp     cartridge1  (cart1)    .sms  .bin  
-snes         cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snesbsx      cartridge1  (cart1)    .sfc  .smc  .fig  .swc  .bin  
-snesdsp      cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snespal      cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snespdsp     cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snespsfx     cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snessfx      cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snesst       cartridge1  (cart1)    .st   .sfc  
-snesst10     cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-snesst11     cartridge   (cart)     .sfc  .smc  .fig  .swc  .bin  
-socrates     (none)
-socratfc     (none)
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+sms          cartridge   (cart)     .bin  .sms  
+sms1         cartridge   (cart)     .bin  .sms  
+             card        (card)     .bin  
+sms1pal      cartridge   (cart)     .bin  .sms  
+             card        (card)     .bin  
+sms2kr       cartridge   (cart)     .bin  .sms  
+smsj         cartridge   (cart)     .bin  .sms  
+             card        (card)     .bin  
+smspal       cartridge   (cart)     .bin  .sms  
+smssdisp     cartridge1  (cart1)    .bin  .sms  
+             cartridge2  (cart2)    .bin  .sms  
+             cartridge3  (cart3)    .bin  .sms  
+             cartridge4  (cart4)    .bin  .sms  
+             cartridge5  (cart5)    .bin  .sms  
+             cartridge6  (cart6)    .bin  .sms  
+             cartridge7  (cart7)    .bin  .sms  
+             cartridge8  (cart8)    .bin  .sms  
+             cartridge9  (cart9)    .bin  .sms  
+             cartridge10 (cart10)   .bin  .sms  
+             cartridge11 (cart11)   .bin  .sms  
+             cartridge12 (cart12)   .bin  .sms  
+             cartridge13 (cart13)   .bin  .sms  
+             cartridge14 (cart14)   .bin  .sms  
+             cartridge15 (cart15)   .bin  .sms  
+             cartridge16 (cart16)   .bin  .sms  
+             card1       (card1)    .bin  
+             card2       (card2)    .bin  
+             card3       (card3)    .bin  
+             card4       (card4)    .bin  
+             card5       (card5)    .bin  
+             card6       (card6)    .bin  
+             card7       (card7)    .bin  
+             card8       (card8)    .bin  
+             card9       (card9)    .bin  
+             card10      (card10)   .bin  
+             card11      (card11)   .bin  
+             card12      (card12)   .bin  
+             card13      (card13)   .bin  
+             card14      (card14)   .bin  
+             card15      (card15)   .bin  
+             card16      (card16)   .bin  
+snes         cartridge   (cart)     .sfc  
+snespal      cartridge   (cart)     .sfc  
+socrates     cartridge   (cart)     .bin  
+socratfc     cartridge   (cart)     .bin  
+softbox      floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
 sol20        cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 sorcerer     printer     (prin)     .prn  
              snapshot    (dump)     .snp  
              quickload   (quik)     .bin  
              cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
              cartridge   (cart)     .rom  .bin  
+sorcererd    printer     (prin)     .prn  
+             snapshot    (dump)     .snp  
+             quickload   (quik)     .bin  
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+             cartridge   (cart)     .rom  .bin  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 soundic      cartridge   (cart)     .bin  
 sp3e8bit     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 sp3eata      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 sp3ezcf      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-sp9000       cassette1   (cass1)    .wav  .tap  
-             quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+space84      floppydisk1 (flop1)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .do   .dsk  .bin  .po   .nib  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  
 spc1000      cassette    (cass)     .wav  
-spc4000      quickload   (quik)     .tvc  
+spc4000      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
+spc800       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 spec128      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -2588,17 +4419,20 @@ specide      snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 specimx      cassette    (cass)     .wav  .rks  
-             floppydisk1 (flop1)    .odi  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .odi  .cpm  .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 specpl2a     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 specpl3e     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 specpls2     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -2607,7 +4441,8 @@ specpls3     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 spectrum     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
@@ -2620,285 +4455,466 @@ spektrbk     snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
 spt1500      (none)
 spt1700      (none)
 spt1740      (none)
-sr16         (none)
+sq1          midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+sq80         midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+sqrack       midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+sr16         cassette    (cass)     .wav  
+ssam88s      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 ssem         cartridge   (cart)     .snp  .asm  
 ssystem3     (none)
-st           floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st           floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_de        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_de        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_es        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_es        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_fr        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_fr        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_nl        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_nl        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_se        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_se        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_sg        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_sg        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-st_uk        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+st_uk        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-stbook       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste          floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste          floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_de       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_de       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_es       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_es       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_fr       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_fr       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_it       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_it       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_se       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_se       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_sg       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-ste_sg       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ste_uk       floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-             cartridge   (cart)     .bin  .rom  
-ste_uk       floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
 stopthie     (none)
-studio2      cartridge   (cart)     .st2  .bin  
+studio2      cartridge   (cart)     .st2  .bin  .rom  
 sun1         (none)
-super6       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+sun2_120     (none)
+sun2_50      (none)
+sun3_110     (none)
+sun3_150     (none)
+sun3_260     (none)
+sun3_460     (none)
+sun3_50      (none)
+sun3_60      (none)
+sun3_80      (none)
+sun3_e       (none)
+sun4_20      (none)
+sun4_300     (none)
+sun4_40      (none)
+sun4_50      (none)
+sun4_60      (none)
+sun4_75      (none)
+sun_s10      (none)
+sun_s20      (none)
+super6       floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 super80      printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 super80d     printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 super80e     printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 super80m     printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 super80r     printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 super80v     printer     (prin)     .prn  
              quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-             cartridge   (cart)     .rom  
 supercon     (none)
-supergb      cartridge   (cart)     .gb   .gmb  .cgb  .gbc  .sgb  .bin  
-superpet     cassette1   (cass1)    .wav  .tap  
+supergb      cartridge   (cart)     .bin  .gb   .gbc  
+superpet     floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cassette    (cass)     .wav  .tap  
              quickload   (quik)     .p00  .prg  
-             cartridge1  (cart1)    .a0   
-             floppydisk1 (flop1)    .d80  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .bin  .rom  
+             cartridge2  (cart2)    .bin  .rom  
+superslv     (none)
 supracan     cartridge   (cart)     .bin  
 sv328n80     printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 sv328p80     printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 svi318       printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 svi318n      printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 svi328       printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 svi328n      printer     (prin)     .prn  
              cassette    (cass)     .wav  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge   (cart)     .rom  
 svi728       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 svi738       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+svi738pl     printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 svi738sw     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 svision      cartridge   (cart)     .bin  .ws   .sv   
 svisionn     cartridge   (cart)     .bin  .ws   .sv   
 svisionp     cartridge   (cart)     .bin  .ws   .sv   
 svisions     cartridge   (cart)     .bin  .ws   .sv   
+svmu         quickload   (quik)     .vms  .bin  
 swtpc        (none)
 swyft        (none)
-sx64         quickload   (quik)     .p00  .prg  .t64  
-             cartridge1  (cart1)    .crt  .80   
+sx16         printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+sx64         cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+sx64p        cassette    (cass)     .wav  .tap  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
 sym1         (none)
 sys2900      (none)
 sys80        cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 systec       (none)
 t1000hx      printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 t1000rl      printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+t1000sl2     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 t1000sx      printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+t1000tl2     printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 t1000tx      printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-t2000sx      printer1    (prin1)    .prn  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk  (flop)     .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+t2000sx      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk    (hard)     .chd  .hd   
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 t9000        printer     (prin)     .prn  
              cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 tadpc200     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 tadpc20a     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 tandy102     printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .rom  .bin  
 tandy200     printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .rom  .bin  
-tandy2k      floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tandy2k      floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-tandy2khd    floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tandy2khd    floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
-tanodr64     printer     (prin)     .prn  
-             snapshot    (dump)     .pak  
-             cassette    (cass)     .wav  .cas  
+             harddisk    (hard)     .chd  .hd   
+tanodr64     cassette    (cass)     .wav  .cas  
+             printer     (prin)     .prn  
+             cartridge   (cart)     .ccc  .rom  
              floppydisk1 (flop1)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .os9  .vdk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 tbbympt3     cartridge   (cart)     .bin  
 tc2048       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
 tccosmos     cartridge   (cart)     .bin  
+tdv2324      floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 tec1         (none)
-tecjmon      (none)
-tek4051      (none)
-tek4052a     (none)
+tecjmon      cassette    (cass)     .wav  
+tek4051      cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
+tek4052a     cartridge1  (cart1)    .bin  
+             cartridge2  (cart2)    .bin  
 tek4107a     (none)
 tek4109a     (none)
 telefevr     cartridge   (cart)     .bin  
-telngtcs     quickload   (quik)     .tvc  
+telngtcs     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 telstrat     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 tempestm     cartridge   (cart)     .bin  
 terak        (none)
-tg16         cartridge   (cart)     .pce  .bin  
-             cdrom       (cdrm)     .chd  
-ti73         TI85 Serial (ser)      .73p  .73s  .73i  .73n  .73c  .73l  .73k  .73m  .73v  .73d  .73e  .73r  .73g  
+test410      (none)
+test420      (none)
+tg16         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+             cartridge   (cart)     .pce  .bin  
+ti73         (none)
 ti81         (none)
 ti81v2       (none)
-ti82         TI85 Serial (ser)      .82p  .82s  .82i  .82n  .82c  .82l  .82k  .82m  .82v  .82d  .82e  .82r  .82g  
+ti82         (none)
 ti83         (none)
-ti83p        TI85 Serial (ser)      .82p  .82s  .82i  .82n  .82c  .82l  .82k  .82m  .82v  .82d  .82e  .82r  .82g  .83p  .83s  .83i  .83n  .83c  .83l  .83k  .83m  .83v  .83d  .83e  .83r  .83g  .8xc  .8xd  .8xg  .8xi  .8xl  .8xm  .8xn  .8xp  .8xs  .8xt  .8xv  .8xw  .8xy  .8xz  
+ti83p        (none)
 ti83pse      (none)
 ti84pse      (none)
 ti85         snapshot    (dump)     .sav  
-             TI85 Serial (ser)      .85p  .85s  .85i  .85n  .85c  .85l  .85k  .85m  .85v  .85d  .85e  .85r  .85g  .85b  
 ti86         snapshot    (dump)     .sav  
-             TI85 Serial (ser)      .85p  .85s  .85i  .85n  .85c  .85l  .85k  .85m  .85v  .85d  .85e  .85r  .85g  .85b86p.86s  .86i  .86n  .86c  .86l  .86k  .86m  .86v  .86d  .86e  .86r  .86g  
 ti89         (none)
 ti89t        (none)
 ti92         (none)
 ti92p        (none)
 ti990_10     harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
              magtape1    (magt1)    .tap  
+             magtape2    (magt2)    .tap  
+             magtape3    (magt3)    .tap  
+             magtape4    (magt4)    .tap  
 ti990_4      floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 ti99_224     (none)
 ti99_232     (none)
-ti99_4       cartridge1  (cart1)    .rpk  .bin  
-             memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+ti99_4       cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette1   (cass1)    .wav  
-ti99_4a      cartridge1  (cart1)    .rpk  .bin  
-             memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+             cassette2   (cass2)    .wav  
+ti99_4a      cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette1   (cass1)    .wav  
-ti99_4ae     cartridge1  (cart1)    .rpk  .bin  
-             memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+             cassette2   (cass2)    .wav  
+ti99_4ae     cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette1   (cass1)    .wav  
-ti99_4e      cartridge1  (cart1)    .rpk  .bin  
-             memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+             cassette2   (cass2)    .wav  
+ti99_4e      cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette1   (cass1)    .wav  
-ti99_4ev     cartridge1  (cart1)    .rpk  .bin  
-             memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+             cassette2   (cass2)    .wav  
+ti99_4ev     cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette1   (cass1)    .wav  
-ti99_4p      memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
-             floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cassette2   (cass2)    .wav  
+ti99_4p      floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette    (cass)     .wav  
-ti99_8       memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+ti99_4qe     cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
-             cassette    (cass)     .wav  
-             cartridge1  (cart1)    .rpk  .bin  
-ti99_8e      memcard     (memc)     .smc  
-             serial1     (serl1)    .     
-             parallel    (parl)     .     
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+ti99_4qi     cartridge   (cart)     .rpk  
              floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
+ti99_8       cartridge   (cart)     .rpk  
+             floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
              cassette    (cass)     .wav  
-             cartridge1  (cart1)    .rpk  .bin  
-tiki100      floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-tim011       (none)
+ti99_8e      cartridge   (cart)     .rpk  
+             floppydisk1 (flop1)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dtk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             cassette    (cass)     .wav  
+tiki100      floppydisk1 (flop1)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+tim011       floppydisk1 (flop1)    .imd  .mfi  .mfm  
+             floppydisk2 (flop2)    .imd  .mfi  .mfm  
+             floppydisk3 (flop3)    .imd  .mfi  .mfm  
+             floppydisk4 (flop4)    .imd  .mfi  .mfm  
+tim100       (none)
+tk2000       cassette    (cass)     .wav  
 tk80         (none)
 tk80bs       (none)
 tk85         cassette    (cass)     .wav  .p    .81   
@@ -2910,77 +4926,139 @@ tk95         snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .rom  
-tmc1800      quickload   (quik)     .bin  
-             cassette    (cass)     .wav  
 tmc2000      quickload   (quik)     .bin  
              cassette    (cass)     .wav  
-tmc2000e     printer     (prin)     .prn  
-             cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tmc2000e     cassette    (cass)     .wav  
 tmc600s2     printer     (prin)     .prn  
              cassette    (cass)     .wav  
-             floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 to7          printer     (prin)     .prn  
              cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 to770        printer     (prin)     .prn  
              cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 to770a       printer     (prin)     .prn  
              cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
 to8          cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
 to8d         cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
 to9          cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
              printer     (prin)     .prn  
 to9p         cassette    (cass)     .wav  .k7   
              floppydisk1 (flop1)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .fd   .sap  .qd   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .m7   .rom  
-             serial1     (serl1)    .txt  
+             serial1     (serl1)    .     
+             serial2     (serl2)    .     
+             serial3     (serl3)    .     
+             printer     (prin)     .prn  
+tonto        floppydisk1 (flop1)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cassette1   (cass1)    .mdv  
+             cassette2   (cass2)    .mdv  
+             cartridge   (cart)     .bin  .rom  
              printer     (prin)     .prn  
 tpc310       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+tpp311       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+tps312       printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 trakcvg      cartridge   (cart)     .bin  
 tricep       (none)
 trs80        cassette    (cass)     .wav  
 trs80l2      cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
-trs80m16     printer     (prin)     .prn  
-             floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-trs80m2      printer     (prin)     .prn  
-             floppydisk  (flop)     .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+trs80m16     floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+trs80m2      floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
 trs80m3      cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 trs80m4      cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 trs80m4p     cassette    (cass)     .wav  .cas  
              quickload   (quik)     .cmd  
              floppydisk1 (flop1)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .dsk  .dmk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              printer     (prin)     .prn  
 trs80pc3     (none)
 trsm100      printer     (prin)     .prn  
@@ -2993,36 +5071,62 @@ ts2068       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  
              cartridge   (cart)     .dck  
-tt030        floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+ts802        (none)
+ts802h       (none)
+ts803h       (none)
+ts816        (none)
+tt030        floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-tt030_de     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tt030_de     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-tt030_fr     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tt030_fr     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-tt030_pl     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tt030_pl     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
-tt030_uk     floppydisk1 (flop1)    .st   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+tt030_uk     floppydisk  (flop)     .st   .msa  .stx  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              printer     (prin)     .prn  
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
              cartridge   (cart)     .bin  .rom  
 tunixha      cartridge   (cart)     .bin  
 tutor        printer     (prin)     .prn  
              cassette    (cass)     .wav  
              cartridge   (cart)     .bin  
-tvc4000      quickload   (quik)     .tvc  
+tv950        (none)
+tvc4000      quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-tvc64        (none)
-tvc64p       (none)
-tvc64pru     (none)
+tvc64        printer     (prin)     .prn  
+             cartridge   (cart)     .crt  .rom  .bin  
+             cassette    (cass)     .wav  .cas  
+             quickload   (quik)     .cas  
+tvc64p       printer     (prin)     .prn  
+             cartridge   (cart)     .crt  .rom  .bin  
+             cassette    (cass)     .wav  .cas  
+             quickload   (quik)     .cas  
+tvc64pru     printer     (prin)     .prn  
+             cartridge   (cart)     .crt  .rom  .bin  
+             cassette    (cass)     .wav  .cas  
+             quickload   (quik)     .cas  
 tvg2000      cartridge   (cart)     .bin  
 tvlinkp      cartridge   (cart)     .bin  .ws   .sv   
 tx0_64kw     punchtape1  (ptap1)    .tap  .rim  
+             punchtape2  (ptap2)    .tap  .rim  
              printer     (prin)     .typ  
              magtape     (magt)     .tap  
 tx0_8kw      punchtape1  (ptap1)    .tap  .rim  
+             punchtape2  (ptap2)    .tap  .rim  
              printer     (prin)     .typ  
              magtape     (magt)     .tap  
 tx8000       printer     (prin)     .prn  
@@ -3030,6 +5134,7 @@ tx8000       printer     (prin)     .prn
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 uk101        cassette    (cass)     .wav  
 uk2086       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
@@ -3038,116 +5143,171 @@ uk2086       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .s
 uknc         (none)
 unior        (none)
 unistar      (none)
+unitron      floppydisk1 (flop1)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .img  .image.dc   .dc42 .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
 ut88         cassette    (cass)     .wav  .rku  
 ut88mini     cassette    (cass)     .wav  .rku  
 uts20        (none)
 uvc          (none)
-v1050        floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+uzebox       cartridge   (cart)     .bin  .uze  
+v1050        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
              printer     (prin)     .prn  
 v200         (none)
-vbc          (none)
+v364         cassette    (cass)     .wav  .tap  
+             cartridge1  (cart1)    .rom  .bin  
+             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             cartridge2  (cart2)    .rom  .bin  
+             quickload   (quik)     .p00  .prg  
+v6809        (none)
+van16        (none)
+van32        (none)
+vax785       floppydisk1 (flop1)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .img  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 vboy         cartridge   (cart)     .vb   .bin  
-vc4000       quickload   (quik)     .tvc  
+vbrc         (none)
+vc4000       quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
-vc6000       quickload   (quik)     .tvc  
+vc6000       quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 vcc          (none)
 vcs80        (none)
 vdmaster     cartridge   (cart)     .bin  
 vec1200      cassette    (cass)     .wav  
              floppydisk1 (flop1)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .emr  
 vector06     cassette    (cass)     .wav  
              floppydisk1 (flop1)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .fdd  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
              cartridge   (cart)     .emr  
-vector1      (none)
+vector1      floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 vector4      (none)
 vectrex      cartridge   (cart)     .bin  .gam  .vec  
 vesta        cassette    (cass)     .wav  .tap  .cas  
+vfx          midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+vfxsd        midiin      (min)      .mid  
+             midiout     (mout)     .mid  
+             floppydisk  (flop)     .img  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 vg5k         cassette    (cass)     .wav  .k7   
              printer     (prin)     .prn  
 vg8000       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8010       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8010f      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg802000     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg802020     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+vg8020f      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8230       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+vg8230j      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8235       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8235f      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 vg8240       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-vic1001      quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
+             cartridge2  (cart2)    .mx1  .rom  
+vic10        cassette    (cass)     .wav  .tap  
+             cartridge   (cart)     .80   .e0   
+vic1001      cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   
-vic20        quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   .crt  
+vic20        cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   
-vic20p       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   .crt  
+vic20_se     cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   
-vic20s       quickload   (quik)     .p00  .prg  
-             cassette    (cass)     .wav  .tap  
+             quickload   (quik)     .p00  .prg  
+             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   .crt  
+vic20p       cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   
-vic64s       quickload   (quik)     .p00  .prg  .t64  
-             cassette    (cass)     .wav  .tap  
-             floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-             cartridge1  (cart1)    .crt  .80   
+             quickload   (quik)     .p00  .prg  
+             cartridge   (cart)     .20   .40   .60   .70   .a0   .b0   .crt  
 victor       cassette    (cass)     .wav  .k7   .cin  .for  
              printer     (prin)     .prn  
-victor9k     floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-vidbrain     cassette    (cass)     .wav  
-             cartridge   (cart)     .bin  
+victor9k     floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+vidbrain     cartridge   (cart)     .bin  
 videopac     cartridge   (cart)     .bin  .rom  
 vii          cartridge   (cart)     .bin  
 vip          quickload   (quik)     .bin  .c8   .c8x  
              cassette    (cass)     .wav  
-vip64        quickload   (quik)     .p00  .prg  .t64  
-             cartridge1  (cart1)    .crt  .80   
+vip64        cassette    (cass)     .wav  .tap  
              floppydisk  (flop)     .g64  .d64  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-visicom      cartridge   (cart)     .st2  .bin  
+             cartridge   (cart)     .80   .a0   .e0   .crt  
+             quickload   (quik)     .p00  .prg  .t64  
+visicom      cartridge   (cart)     .bin  .rom  
 visor        (none)
-vixen        floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+vixen        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 vk100        (none)
-vmdtbase     quickload   (quik)     .tvc  
+vmdtbase     quickload   (quik)     .pgm  .tvc  
              cartridge   (cart)     .rom  .bin  
 votrpss      (none)
 votrtnt      (none)
 vp111        quickload   (quik)     .bin  .c8   .c8x  
              cassette    (cass)     .wav  
-vsaturn      cdrom       (cdrm)     .chd  
+vsaturn      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
              cartridge   (cart)     .bin  
 vsc          (none)
+vsmile       cartridge   (cart)     .bin  
 vt100        (none)
+vt102        (none)
 vt105        (none)
 vt131        (none)
 vt180        (none)
@@ -3160,6 +5320,7 @@ vz200        printer     (prin)     .prn
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 vz2000       cassette    (cass)     .wav  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
@@ -3168,92 +5329,255 @@ vz300        printer     (prin)     .prn
              cassette    (cass)     .wav  .cas  
              cartridge   (cart)     .rom  
              floppydisk1 (flop1)    .dsk  
+             floppydisk2 (flop2)    .dsk  
 wales210     (none)
 walle        (none)
+wangpc       floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+wicat        (none)
 wizzard      cassette    (cass)     .wav  
              printer     (prin)     .prn  
              cartridge   (cart)     .bin  .rom  
-wmega        (none)
-wmegam2      (none)
+wmbullet     floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+wmbulletf    floppydisk  (flop)     .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+             harddisk    (hard)     .chd  .hd   
+wmega        cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+wmegam2      cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
 wofch        (none)
 wscolor      cartridge   (cart)     .ws   .wsc  .bin  
 wswan        cartridge   (cart)     .ws   .wsc  .bin  
 x07          printer     (prin)     .prn  
-             cartridge   (cart)     .k7   .cas  .lst  
+             cartridge   (cart)     .rom  .bin  
+             cassette    (cass)     .wav  .k7   .lst  .cas  
 x1           cartridge   (cart)     .rom  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+x168         floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
 x1turbo      cartridge   (cart)     .rom  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 x1turbo40    cartridge   (cart)     .rom  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
 x1twin       cartridge   (cart)     .rom  
              cassette    (cass)     .wav  .tap  
              floppydisk1 (flop1)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-x68000       floppydisk1 (flop1)    .xdf  .hdm  .2hd  .dim  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+x68000       floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              sasihd      (sasi)     .hdf  
-x68030       floppydisk1 (flop1)    .xdf  .hdm  .2hd  .dim  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+x68030       floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-x68kxvi      floppydisk1 (flop1)    .xdf  .hdm  .2hd  .dim  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
+             harddisk6   (hard6)    .chd  .hd   
+             harddisk7   (hard7)    .chd  .hd   
+x68ksupr     floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
-xegs         floppydisk1 (flop1)    .atr  .dsk  .xfd  
-             cartridge   (cart)     .rom  .bin  
-xerox168     floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-xerox820     floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-xerox820ii   floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
-xeye         (none)
-xor100       floppydisk1 (flop1)    .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
+             harddisk6   (hard6)    .chd  .hd   
+             harddisk7   (hard7)    .chd  .hd   
+x68kxvi      floppydisk1 (flop1)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk3 (flop3)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk4 (flop4)    .xdf  .hdm  .2hd  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             harddisk3   (hard3)    .chd  .hd   
+             harddisk4   (hard4)    .chd  .hd   
+             harddisk5   (hard5)    .chd  .hd   
+             harddisk6   (hard6)    .chd  .hd   
+             harddisk7   (hard7)    .chd  .hd   
+x820         floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+x820ii       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+xb42639      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+xb42639a     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+xb42663      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
              printer     (prin)     .prn  
-xtvga        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+xb42664      floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+xb42664a     floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             harddisk    (hard)     .chd  .hd   
+             printer     (prin)     .prn  
+xegs         floppydisk1 (flop1)    .atr  .dsk  .xfd  
+             floppydisk2 (flop2)    .atr  .dsk  .xfd  
+             floppydisk3 (flop3)    .atr  .dsk  .xfd  
+             floppydisk4 (flop4)    .atr  .dsk  .xfd  
+             cartridge   (cart)     .rom  .bin  
+xeye         cdrom       (cdrm)     .chd  .cue  .toc  .nrg  .gdi  .iso  .cdr  
+xor100       floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             printer     (prin)     .prn  
+xtvga        floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
              harddisk1   (hard1)    .chd  .hd   
+             harddisk2   (hard2)    .chd  .hd   
+             midiin      (min)      .mid  
+             midiout     (mout)     .mid  
 y503iir      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 y503iir2     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 yc64         printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 yis303       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 yis503       printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
+yis503f      printer     (prin)     .prn  
+             cassette    (cass)     .wav  .tap  .cas  
+             floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 yis503ii     printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
+             cartridge2  (cart2)    .mx1  .rom  
 yis503m      printer     (prin)     .prn  
              cassette    (cass)     .wav  .tap  .cas  
              floppydisk1 (flop1)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .dsk  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
              cartridge1  (cart1)    .mx1  .rom  
-z1013        snapshot    (dump)     .z80  
-z1013a2      snapshot    (dump)     .z80  
-z1013k69     snapshot    (dump)     .z80  
-z1013k76     snapshot    (dump)     .z80  
-z1013s60     snapshot    (dump)     .z80  
+             cartridge2  (cart2)    .mx1  .rom  
+z100         floppydisk1 (flop1)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk2 (flop2)    .2d   .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+z1013        cassette    (cass)     .wav  
+             snapshot    (dump)     .z80  
+z1013a2      cassette    (cass)     .wav  
+             snapshot    (dump)     .z80  
+z1013k69     cassette    (cass)     .wav  
+             snapshot    (dump)     .z80  
+z1013k76     cassette    (cass)     .wav  
+             snapshot    (dump)     .z80  
+z1013s60     cassette    (cass)     .wav  
+             snapshot    (dump)     .z80  
 z80dev       (none)
 z80ne        cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 z80net       cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 z80netb      cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
 z80netf      cassette1   (cass1)    .wav  
+             cassette2   (cass2)    .wav  
              floppydisk1 (flop1)    .zmk  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
-z88          (none)
-z9001        (none)
+             floppydisk2 (flop2)    .zmk  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk3 (flop3)    .zmk  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+             floppydisk4 (flop4)    .zmk  .fdi  .td0  .imd  .cqm  .dsk  .d77  .d88  .1dd  
+z88          cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88ch        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88de        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88dk        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88es        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88fi        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88fr        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88it        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88no        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88se        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z88tr        cartridge1  (cart1)    .epr  .bin  
+             cartridge2  (cart2)    .epr  .bin  
+             cartridge3  (cart3)    .epr  .bin  
+z9001        cassette    (cass)     .wav  
 zdsupers     printer1    (prin1)    .prn  
-             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .fdi  .td0  .imd  .cqm  .d77  .d88  .1dd  
+             printer2    (prin2)    .prn  
+             printer3    (prin3)    .prn  
+             floppydisk1 (flop1)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .dsk  .ima  .img  .ufi  .360  .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 zexall       (none)
+zorba        floppydisk1 (flop1)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
+             floppydisk2 (flop2)    .d77  .d88  .1dd  .dfi  .imd  .ipf  .mfi  .mfm  .td0  
 zrt80        (none)
 zsbc3        (none)
+zsl5500      (none)
+zsl5600      (none)
+zslc1000     (none)
+zslc3000     (none)
+zslc750      (none)
+zslc760      (none)
 zvezda       snapshot    (dump)     .ach  .frz  .plusd.prg  .sem  .sit  .sna  .snp  .snx  .sp   .z80  .zx   
              quickload   (quik)     .raw  .scr  
              cassette    (cass)     .wav  .tzx  .tap  .blk  


### PR DESCRIPTION
This is an update of the media list from 14? to mess 150.
New systems, files types and devices supported.
Some of the systems were renamed thus making the old media list incompatible (e.g. a500p) with the current version of MAMEHub.
