### PR TITLE
enabling memory card support for psx out of box

### DIFF
--- a/Binaries/dist/ume.ini.osx
+++ b/Binaries/dist/ume.ini.osx
@@ -12,7 +12,7 @@ hashpath                  ../hash
 samplepath                ../samples
 artpath                   ../artwork
 ctrlrpath                 ../ctrlr
-inipath                   .;ini
+inipath                   ../ini
 fontpath                  .
 cheatpath                 ../cheat
 crosshairpath             ../crosshair

--- a/Binaries/dist/ume.ini.unix
+++ b/Binaries/dist/ume.ini.unix
@@ -11,7 +11,7 @@ hashpath                  ../hash
 samplepath                ../samples
 artpath                   ../artwork
 ctrlrpath                 ../ctrlr
-inipath                   $HOME/.mame;.;ini
+inipath                   ../ini
 fontpath                  .
 cheatpath                 ../cheat
 crosshairpath             ../crosshair

--- a/Binaries/dist/ume.ini.win
+++ b/Binaries/dist/ume.ini.win
@@ -12,7 +12,7 @@ hashpath                  ../hash
 samplepath                ../samples
 artpath                   ../artwork
 ctrlrpath                 ../ctrlr
-inipath                   .;../ini
+inipath                   ../ini
 fontpath                  .
 cheatpath                 ../cheat
 crosshairpath             ../crosshair

--- a/Binaries/ini/pse.ini
+++ b/Binaries/ini/pse.ini
@@ -1,0 +1,5 @@
+#
+# IMAGE DEVICES
+#
+memcard1                  ..\memcards\pse1.mcr
+memcard2                  ..\memcards\pse2.mcr

--- a/Binaries/ini/psj.ini
+++ b/Binaries/ini/psj.ini
@@ -1,0 +1,5 @@
+#
+# IMAGE DEVICES
+#
+memcard1                  ..\memcards\psj1.mcr
+memcard2                  ..\memcards\psj2.mcr

--- a/Binaries/ini/psu.ini
+++ b/Binaries/ini/psu.ini
@@ -1,0 +1,5 @@
+#
+# IMAGE DEVICES
+#
+memcard1                  ..\memcards\psu1.mcr
+memcard2                  ..\memcards\psu2.mcr

--- a/Binaries/ini/psx.ini
+++ b/Binaries/ini/psx.ini
@@ -1,0 +1,5 @@
+#
+# IMAGE DEVICES
+#
+memcard1                  ..\memcards\psx1.mcr
+memcard2                  ..\memcards\psx2.mcr


### PR DESCRIPTION
added memcards and ini folder, created ini's for the various psx systems
so mamehub can find the default folder for each
