### PR TITLE
Initial import of Apple II+ hash file

### DIFF
--- a/Binaries/hash/apple2p.xml
+++ b/Binaries/hash/apple2p.xml
@@ -1,0 +1,6562 @@
+<?xml version="1.0"?>
+<!DOCTYPE softwarelist SYSTEM "softwarelist.dtd">
+<softwarelist description="Apple II+ DSK games" name="apple2p">
+<software name="A-EcrB">
+<description>A-E </description>
+<year>1982</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="71e40e6c" name="A-E (1982)(Broderbund)(Side A)[cr Blade].dsk" offset="0" sha1="a1ec840d54302c67a5b6cea668ffd4c2" size="143360" /></dataarea></part></software>
+<software name="A-Eo">
+<description>A-E </description>
+<year>1982</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="a6e01c2c" name="A-E (1982)(Broderbund)(Side A)[o].dsk" offset="0" sha1="46cf5e5c14000241f027f7b5bdb619bb" size="143363" /></dataarea></part></software>
+<software name="A-EcrB">
+<description>A-E </description>
+<year>1982</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0caf5c79" name="A-E (1982)(Broderbund)(Side B)[cr Blade].dsk" offset="0" sha1="7e5c200ab422b01dfa90a806a5be1f86" size="143360" /></dataarea></part></software>
+<software name="Adventurcr">
+<description>Adventures of Buckaroo Banzai, The </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="61e0f76c" name="Adventures of Buckaroo Banzai, The (19xx)(-)(Side A)[cr].dsk" offset="0" sha1="690063a6240d55c37d4212eba5704c5a" size="143360" /></dataarea></part></software>
+<software name="Adventurcr">
+<description>Adventures of Buckaroo Banzai, The </description>
+<year>19xx</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="86e0177f" name="Adventures of Buckaroo Banzai, The (19xx)(-)(Side B)[cr].dsk" offset="0" sha1="59d70aefbc6273e1771a514e5fdc1e07" size="143360" /></dataarea></part></software>
+<software name="AirheartcrE">
+<description>Airheart </description>
+<year>1986</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6223b013" name="Airheart (1986)(Broderbund)[cr Evil Sock].dsk" offset="0" sha1="aba2ef0f1e3c57737ff4c0f0eece2d52" size="143360" /></dataarea></part></software>
+<software name="AlertcrD">
+<description>Alert </description>
+<year>1985</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2c36e539" name="Alert (1985)(Mindscape)[cr Disk Jockey].dsk" offset="0" sha1="f2fc6a517c2abd9fe538596a09955e38" size="143360" /></dataarea></part></software>
+<software name="AlfTheFi">
+<description>Alf, The First Adventure </description>
+<year>1985</year>
+<publisher>Box Office</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="19f78e62" name="Alf, The First Adventure (1985)(Box Office).dsk" offset="0" sha1="d9e5e4806ed4abc5828e5d740231e6d7" size="143360" /></dataarea></part></software>
+<software name="AlfTheFia">
+<description>Alf, The First Adventure </description>
+<year>1985</year>
+<publisher>Box Office</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6b6e7564" name="Alf, The First Adventure (1985)(Box Office)[a].dsk" offset="0" sha1="b23e5d453643f66b68634d0204884cdf" size="143360" /></dataarea></part></software>
+<software name="AlfTheFi">
+<description>Alf, The First Adventure v3.2 </description>
+<year>1985</year>
+<publisher>Box Office</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="73c93c38" name="Alf, The First Adventure v3.2 (1985)(Box Office).dsk" offset="0" sha1="113dfd214d6dfdc06e3968396d88c533" size="143360" /></dataarea></part></software>
+<software name="AliBabaacrD">
+<description>Ali Baba and the Forty Thieves </description>
+<year>1982</year>
+<publisher>Smith, Stuart</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1217ae9a" name="Ali Baba and the Forty Thieves (1982)(Smith, Stuart)[cr Dr. Death].dsk" offset="0" sha1="7d29caee3e745eacc0f99217b1aaacfd" size="143360" /></dataarea></part></software>
+<software name="AliceinWSav">
+<description>Alice in Wonderland </description>
+<year>1985</year>
+<publisher>Windham Classics</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c09cc01e" name="Alice in Wonderland (1985)(Windham Classics)[Save].dsk" offset="0" sha1="10b57f5d907a1e2f0afa66d0e6d05a5d" size="143360" /></dataarea></part></software>
+<software name="AlpineEncrM">
+<description>Alpine Encounter, The </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="562e5f89" name="Alpine Encounter, The (19xx)(-)(Side A)[cr Mr. Krac-Man].dsk" offset="0" sha1="1abb1f8ca53eaf80e09ddad9b6156a03" size="143360" /></dataarea></part></software>
+<software name="AlpineEncrM">
+<description>Alpine Encounter, The </description>
+<year>19xx</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c782b168" name="Alpine Encounter, The (19xx)(-)(Side B)[cr Mr. Krac-Man].dsk" offset="0" sha1="9cf891425ac9f296779ba67e804b3a74" size="143360" /></dataarea></part></software>
+<software name="AmericancrB">
+<description>American Challenge, The </description>
+<year>1986</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22e8aa44" name="American Challenge, The (1986)(Mindscape)[cr Blade].dsk" offset="0" sha1="4bdc01bfaa355f530eb91b03294c7d68" size="143360" /></dataarea></part></software>
+<software name="AmericancrF">
+<description>American Challenge, The </description>
+<year>1986</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f4320ad1" name="American Challenge, The (1986)(Mindscape)[cr First Class].dsk" offset="0" sha1="a340e013a280d21be7633cb1574785d8" size="143360" /></dataarea></part></software>
+<software name="Amnesia">
+<description>Amnesia </description>
+<year>1986</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d38304c5" name="Amnesia (1986)(Electronic Arts)(Disk 1 of 4).dsk" offset="0" sha1="1631bd90a6fc197ce62bdd9e30d6dd40" size="143360" /></dataarea></part></software>
+<software name="AmnesiacrD">
+<description>Amnesia </description>
+<year>1986</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9150451b" name="Amnesia (1986)(Electronic Arts)(Disk 1 of 4)[cr Digital Gang].dsk" offset="0" sha1="3c0d93db45b5ca89628cd7e477e243a8" size="143360" /></dataarea></part></software>
+<software name="Amnesia">
+<description>Amnesia </description>
+<year>1986</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22131ea6" name="Amnesia (1986)(Electronic Arts)(Disk 2 of 4).dsk" offset="0" sha1="dd60ebe970c0328daa6db59d3e35b331" size="143360" /></dataarea></part></software>
+<software name="Amnesia">
+<description>Amnesia </description>
+<year>1986</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ce2d6688" name="Amnesia (1986)(Electronic Arts)(Disk 3 of 4).dsk" offset="0" sha1="d88edbbda1227a00095b45b04043bbde" size="143360" /></dataarea></part></software>
+<software name="Amnesia">
+<description>Amnesia </description>
+<year>1986</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b86aad3a" name="Amnesia (1986)(Electronic Arts)(Disk 4 of 4).dsk" offset="0" sha1="1b455891c1ffc0f1876c5e0fb302391e" size="143360" /></dataarea></part></software>
+<software name="ArcadeMacrS">
+<description>Arcade Machine, The </description>
+<year>1982</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ad4f225d" name="Arcade Machine, The (1982)(Broderbund)(Disk 1 of 2)[cr Super Pirates].dsk" offset="0" sha1="7c482e84658b8c0a31bc8f5f054c24e5" size="143360" /></dataarea></part></software>
+<software name="ArcadeMacrS">
+<description>Arcade Machine, The </description>
+<year>1982</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="74b28fb5" name="Arcade Machine, The (1982)(Broderbund)(Disk 2 of 2)[cr Super Pirates].dsk" offset="0" sha1="f85ec4632133e7d2a6e83a913c479e22" size="143360" /></dataarea></part></software>
+<software name="ArchoncrC">
+<description>Archon </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="217b6c06" name="Archon (1984)(Electronic Arts)[cr Cracking Elite Software].dsk" offset="0" sha1="7262979f5396bff0e6074a1fd3285b8a" size="143360" /></dataarea></part></software>
+<software name="ArchoncrM">
+<description>Archon </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="34acae6e" name="Archon (1984)(Electronic Arts)[cr Midwest Pirates Guild].dsk" offset="0" sha1="c4a2c95e30a49c755726349dd9eb8f98" size="143360" /></dataarea></part></software>
+<software name="ArchoncrM">
+<description>Archon </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="35b1286a" name="Archon (1984)(Electronic Arts)[cr Midwest Pirates Guild][o].dsk" offset="0" sha1="1bb9e25f1585ba1335597cffc4eaff4d" size="143363" /></dataarea></part></software>
+<software name="ArchonIIcrR">
+<description>Archon II - Adept </description>
+<year>1985</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fcf7b2e8" name="Archon II - Adept (1985)(Electronic Arts)[cr Racketeers].dsk" offset="0" sha1="2b5eece32e19f4786a26791a1d97d9e9" size="143360" /></dataarea></part></software>
+<software name="ArcticfocrF">
+<description>Arcticfox </description>
+<year>1986</year>
+<publisher>Dynamix</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="38649e56" name="Arcticfox (1986)(Dynamix)[cr First Class][o].dsk" offset="0" sha1="192dc20ed58bcd0b36cab0206fc06e98" size="143363" /></dataarea></part></software>
+<software name="Arkanoid">
+<description>Arkanoid Editor </description>
+<year>1989</year>
+<publisher>fr</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0bff80f6" name="Arkanoid Editor (1989)(2c)(fr).dsk" offset="0" sha1="19a548e64afcbcdcb805c68d3494a30a" size="143360" /></dataarea></part></software>
+<software name="ArtesiancrN">
+<description>Artesians </description>
+<year>19xx</year>
+<publisher>Reno Soft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4446cd85" name="Artesians (19xx)(Reno Soft)[cr Nibbler].dsk" offset="0" sha1="a270063f77640818fb000ab5f45df729" size="143360" /></dataarea></part></software>
+<software name="Aztec">
+<description>Aztec </description>
+<year>1982</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a4d4eae7" name="Aztec (1982)(Datamost).dsk" offset="0" sha1="dbe55a0707f9205f06eac50882ec3642" size="143360" /></dataarea></part></software>
+<software name="B-24RDO">
+<description>B-24 </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="196ea757" name="B-24 (1987)(SSI)[RDOS].dsk" offset="0" sha1="c0ab15d850294dfd16597072a97fc479" size="143360" /></dataarea></part></software>
+<software name="BallBlas">
+<description>Ball Blaster </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1dd166d2" name="Ball Blaster (19xx)(-).dsk" offset="0" sha1="f61c2879f9e9bb303fa0edc08dc04b07" size="143360" /></dataarea></part></software>
+<software name="Ballyhoo">
+<description>Ballyhoo </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9148e38b" name="Ballyhoo (1986)(Infocom).dsk" offset="0" sha1="d18d1ce522dd2037a5cdc094f6d14985" size="143360" /></dataarea></part></software>
+<software name="Banditso">
+<description>Bandits </description>
+<year>1982</year>
+<publisher>Sirius Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="c17024c9" name="Bandits (1982)(Sirius Software)[o].dsk" offset="0" sha1="eb2db62a545deae949af7ee30967ef1b" size="143363" /></dataarea></part></software>
+<software name="BaratinB">
+<description>Baratin Blues </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1d20249b" name="Baratin Blues (1986)(Froggy Software)(fr)(Side A).dsk" offset="0" sha1="4ffc6f021b09365e4e254a0d3d67c168" size="143360" /></dataarea></part></software>
+<software name="BaratinBa">
+<description>Baratin Blues </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d510b552" name="Baratin Blues (1986)(Froggy Software)(fr)(Side A)[a].dsk" offset="0" sha1="ff572b26f837dc16b57f183d1bdad2b1" size="143360" /></dataarea></part></software>
+<software name="BaratinB">
+<description>Baratin Blues </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9f8698dc" name="Baratin Blues (1986)(Froggy Software)(fr)(Side B).dsk" offset="0" sha1="0e2ca9e7e9620d4ee62780e6bc3a9203" size="143360" /></dataarea></part></software>
+<software name="BaratinBa">
+<description>Baratin Blues </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6ca89c81" name="Baratin Blues (1986)(Froggy Software)(fr)(Side B)[a].dsk" offset="0" sha1="3de7095de874d7eda9f7fc9991880a20" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale II - The Destiny Knight, The </description>
+<year>1986</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b6843a24" name="Bard's Tale II - The Destiny Knight, The (1986)(Electronic Arts)(Disk 1 of 4).dsk" offset="0" sha1="85e2c06a8c88f29a2c757749f5cc8bcb" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale II - The Destiny Knight, The </description>
+<year>1986</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d392ec46" name="Bard's Tale II - The Destiny Knight, The (1986)(Electronic Arts)(Disk 2 of 4)(Character).dsk" offset="0" sha1="0dc238aad5f1af31fa5489ac8a9bcbb3" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale II - The Destiny Knight, The </description>
+<year>1986</year>
+<publisher>Dungeon 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b4b02734" name="Bard's Tale II - The Destiny Knight, The (1986)(Electronic Arts)(Disk 3 of 4)(Dungeon 1).dsk" offset="0" sha1="34070b37fadc15f2a661b2215a6642b1" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale II - The Destiny Knight, The </description>
+<year>1986</year>
+<publisher>Dungeon 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1a97f984" name="Bard's Tale II - The Destiny Knight, The (1986)(Electronic Arts)(Disk 4 of 4)(Dungeon 2).dsk" offset="0" sha1="28ca705aa1c9627df50ff0c2b171352d" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale III - The Thief of Fate, The </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143358">
+<rom crc="a8798140" name="Bard's Tale III - The Thief of Fate, The (1988)(Interplay)(Disk 1 of 4).dsk" offset="0" sha1="7d92ee54afc96c6c723a288f055cc0e3" size="143358" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale III - The Thief of Fate, The </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143358">
+<rom crc="7c748e7d" name="Bard's Tale III - The Thief of Fate, The (1988)(Interplay)(Disk 2 of 4)(Character).dsk" offset="0" sha1="0eac76079e3fc129c350bc468c988331" size="143358" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale III - The Thief of Fate, The </description>
+<year>1988</year>
+<publisher>Dungeon 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143195">
+<rom crc="9af87667" name="Bard's Tale III - The Thief of Fate, The (1988)(Interplay)(Disk 3 of 4)(Dungeon 1).dsk" offset="0" sha1="b060522afca9a1caac9e4b1d22180fd8" size="143195" /></dataarea></part></software>
+<software name="Bard'sTaf">
+<description>Bard's Tale III - The Thief of Fate, The </description>
+<year>1988</year>
+<publisher>Dungeon 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e713ebe2" name="Bard's Tale III - The Thief of Fate, The (1988)(Interplay)(Disk 3 of 4)(Dungeon 1)[f].dsk" offset="0" sha1="fe85d49bd392e60037fe7d4e467e92d8" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale III - The Thief of Fate, The </description>
+<year>1988</year>
+<publisher>Dungeon 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143358">
+<rom crc="d6f2595b" name="Bard's Tale III - The Thief of Fate, The (1988)(Interplay)(Disk 3 of 4)(Dungeon 2).dsk" offset="0" sha1="f94f6b38fcdce75ed0046c326920488e" size="143358" /></dataarea></part></software>
+<software name="Bard'sTacrC">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Boot</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ee0c10db" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 1 of 4)(Boot)[cr Club X].dsk" offset="0" sha1="7fd000cc7f5e063a46e3ab0085fb7ea5" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacrN">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Boot</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ddbd6a83" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 1 of 4)(Boot)[cr Numero 6].dsk" offset="0" sha1="dc8d0a2b6d4e2b41e78bfa5452599e91" size="143360" /></dataarea></part></software>
+<software name="Bard'sTa">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3be3d4a7" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 2 of 4)(Character).dsk" offset="0" sha1="c5fb3a438868bffc5a4c6e472913cf54" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacrC">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f55ba619" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 2 of 4)(Character)[cr Club X].dsk" offset="0" sha1="e0b3340d0d27b89f824ab415dd8821cd" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacr">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c4dfab6f" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 2 of 4)(Character)[cr].dsk" offset="0" sha1="d1e670871c385c5e3f97115aaffe1027" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacrC">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Dungeon 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="76f2d041" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 3 of 4)(Dungeon 1)[cr Club X].dsk" offset="0" sha1="54a68f10d850e85494c6a16386b65816" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacr">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Dungeon 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e94d34e4" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 3 of 4)(Dungeon 1)[cr].dsk" offset="0" sha1="0600d2f813adce9f45c46531514cc133" size="143360" /></dataarea></part></software>
+<software name="Bard'sTacr">
+<description>Bard's Tale, The </description>
+<year>1985</year>
+<publisher>Dungeon 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eae221ba" name="Bard's Tale, The (1985)(Electronic Arts)(Disk 4 of 4)(Dungeon 2)[cr].dsk" offset="0" sha1="af9f2b7f252e2ec51b75af97a59417d8" size="143360" /></dataarea></part></software>
+<software name="BattalioRDO">
+<description>Battalion Commander </description>
+<year>19xx</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c24e6631" name="Battalion Commander (19xx)(SSI)[RDOS].dsk" offset="0" sha1="c0160b0408b803df597bb2e6975d62ec" size="143360" /></dataarea></part></software>
+<software name="BattlefoRDO">
+<description>Battle for Normandy </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7c691cae" name="Battle for Normandy (1982)(SSI)[RDOS].dsk" offset="0" sha1="90924ad8bc80ad28deea80f5d738eadd" size="143360" /></dataarea></part></software>
+<software name="BattleGrRDO">
+<description>Battle Group </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2ece2239" name="Battle Group (1986)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="784f4ce5ad706aaa1cdb6fd5c374e023" size="143360" /></dataarea></part></software>
+<software name="BattleGrRDO">
+<description>Battle Group </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f7e14047" name="Battle Group (1986)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="3e3afc5c845f3d76a06a8c0e9edc2844" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Antietam </description>
+<year>1985</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="76366fee" name="Battle of Antietam (1985)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="badf590eb7d2fa49ef380f22b9ce08e8" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Antietam </description>
+<year>1985</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83074fd7" name="Battle of Antietam (1985)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="3d9516e91ec2f2c295f813707aa69924" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5c05c8ab" name="Battle of Napoleon (1988)(SSI)(Disk 1 of 4)[RDOS].dsk" offset="0" sha1="9ba6686ea42a6b3f66cc13f58378509e" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Game</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f530e6e9" name="Battle of Napoleon (1988)(SSI)(Disk 2 of 4 Side A)(Game)[RDOS].dsk" offset="0" sha1="4f3689e7418b5e5669ca55f297fdeed8" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Game</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="344a0139" name="Battle of Napoleon (1988)(SSI)(Disk 2 of 4 Side B)(Game)[RDOS].dsk" offset="0" sha1="14e81c59e167fefffd76a04708eb313d" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Scenario</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2c3b2f0c" name="Battle of Napoleon (1988)(SSI)(Disk 3 of 4 Side A)(Scenario)[RDOS].dsk" offset="0" sha1="7e7f1469be7fb887118b8a70504374cb" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Scenario</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="02e97a47" name="Battle of Napoleon (1988)(SSI)(Disk 3 of 4 Side B)(Scenario)[RDOS].dsk" offset="0" sha1="d63a13c31804905bed84e78b518155ae" size="143360" /></dataarea></part></software>
+<software name="Battleof">
+<description>Battle of Napoleon </description>
+<year>1988</year>
+<publisher>Save</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1964c542" name="Battle of Napoleon (1988)(SSI)(Disk 4 of 4)(Save).dsk" offset="0" sha1="0fed475c24293f58b4b4ebaac33bc52f" size="143360" /></dataarea></part></software>
+<software name="BattleofRDO">
+<description>Battle of Shiloh, The </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="60132e7a" name="Battle of Shiloh, The (1981)(SSI)[RDOS].dsk" offset="0" sha1="57cc9aef614a138b0870c3fe553768a7" size="143360" /></dataarea></part></software>
+<software name="BattlecrRDO">
+<description>Battlecruiser 1 </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="31a883c6" name="Battlecruiser 1 (1987)(SSI)[RDOS].dsk" offset="0" sha1="cd581045953ac3693b909d1845912eba" size="143360" /></dataarea></part></software>
+<software name="BattlecrRDO">
+<description>Battlecruiser 2 </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8fe6c98c" name="Battlecruiser 2 (1987)(SSI)[RDOS].dsk" offset="0" sha1="ac80a3a72d126708b2d8580d145daf75" size="143360" /></dataarea></part></software>
+<software name="Battletecr6">
+<description>Battletech </description>
+<year>1988</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="09a9fe2a" name="Battletech (1988)(Infocom - Westwood)(Disk 1 of 2)[cr 6502 Crew][RDOS].dsk" offset="0" sha1="b6aae132bd49842f458beda845700a9d" size="143360" /></dataarea></part></software>
+<software name="BattleteRDO">
+<description>Battletech </description>
+<year>1988</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6b926187" name="Battletech (1988)(Infocom - Westwood)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="7b2975b8824a6639bc3bb139b757e217" size="143360" /></dataarea></part></software>
+<software name="Battlete">
+<description>Battletech </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="38da70ce" name="Battletech (1988)(Infocom - Westwood)(Disk 2 of 2)(Character).dsk" offset="0" sha1="d396f318e7ac8e1fe361816a67210870" size="143360" /></dataarea></part></software>
+<software name="Battletea">
+<description>Battletech </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ae823c15" name="Battletech (1988)(Infocom - Westwood)(Disk 2 of 2)(Character)[a].dsk" offset="0" sha1="c99b8f4d3870127275ac4b9875a2a165" size="143360" /></dataarea></part></software>
+<software name="Battletecr6">
+<description>Battletech </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2b765939" name="Battletech (1988)(Infocom - Westwood)(Disk 2 of 2)(Character)[cr 6502 Crew].dsk" offset="0" sha1="dfadf81368ab0bf279a98dbb962f98a7" size="143360" /></dataarea></part></software>
+<software name="BeachLancrB">
+<description>Beach Landing </description>
+<year>1984</year>
+<publisher>Optimun Resource</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="31f2e62e" name="Beach Landing (1984)(Optimun Resource)[cr Black Bag].dsk" offset="0" sha1="44e355ff08f93dcb9f3a1d9142e9f7fe" size="143360" /></dataarea></part></software>
+<software name="Beach-He">
+<description>Beach-Head </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b0ef40fa" name="Beach-Head (1985)(Access).dsk" offset="0" sha1="c6eaede779f428e61b5bfa2786f3b0a6" size="143360" /></dataarea></part></software>
+<software name="Beach-HecrC">
+<description>Beach-Head </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="86c5c3b4" name="Beach-Head (1985)(Access)[cr Copyart].dsk" offset="0" sha1="ce992601429abc77691454b3af517005" size="143360" /></dataarea></part></software>
+<software name="Beach-He">
+<description>Beach-Head II </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bf29aab2" name="Beach-Head II (1985)(Access).dsk" offset="0" sha1="57434256fab967937c96f59b5d406017" size="143360" /></dataarea></part></software>
+<software name="Beach-HecrD">
+<description>Beach-Head II </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9b5a3deb" name="Beach-Head II (1985)(Access)[cr Disk Jockey].dsk" offset="0" sha1="e224ff189b39f171d36d7987deb2a651" size="143360" /></dataarea></part></software>
+<software name="Beach-HecrD">
+<description>Beach-Head II </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="646c8c72" name="Beach-Head II (1985)(Access)[cr Disk Jockey][a].dsk" offset="0" sha1="fbaf445bbeec10aa66fa1e6aeeb29928" size="143360" /></dataarea></part></software>
+<software name="BeerRuncrB">
+<description>Beer Run </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="df4e52a4" name="Beer Run (19xx)(-)[cr Black Bag].dsk" offset="0" sha1="bff083ddc5f88e4580a6f7376373b0ee" size="143360" /></dataarea></part></software>
+<software name="Berzap!b">
+<description>Berzap! </description>
+<year>1984</year>
+<publisher>Infinity Limited</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="948c69af" name="Berzap! (1984)(Infinity Limited)[b].dsk" offset="0" sha1="2df5d07f5a59238513a943b2dd4829ed" size="143360" /></dataarea></part></software>
+<software name="Berzap!crK">
+<description>Berzap! </description>
+<year>1984</year>
+<publisher>Infinity Limited</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="9df3945f" name="Berzap! (1984)(Infinity Limited)[cr Krackle - Magic Merlin][o].dsk" offset="0" sha1="01aa76899b05ce653047b2b526441835" size="143363" /></dataarea></part></software>
+<software name="Berzap!v">
+<description>Berzap! v2.1 </description>
+<year>1985</year>
+<publisher>Infinity Limited</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7175e6b7" name="Berzap! v2.1 (1985)(Infinity Limited).dsk" offset="0" sha1="2c5eb2702a7f3e6cf0dc124c79e8208b" size="143360" /></dataarea></part></software>
+<software name="BestofBi">
+<description>Best of Bill Budge, The </description>
+<year>1979</year>
+<publisher>Bill Budge</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3bc1f214" name="Best of Bill Budge, The (1979)(Bill Budge).dsk" offset="0" sha1="eb1a3ed0da2c181085958acdeef7c5da" size="143360" /></dataarea></part></software>
+<software name="BestofBia">
+<description>Best of Bill Budge, The </description>
+<year>1979</year>
+<publisher>Bill Budge</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="85b497f5" name="Best of Bill Budge, The (1979)(Bill Budge)[a].dsk" offset="0" sha1="62fac060ef7ca64773f05d60bea60784" size="143360" /></dataarea></part></software>
+<software name="BeteduGecrA">
+<description>Bete du Gevaudan, La </description>
+<year>198x</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aad13850" name="Bete du Gevaudan, La (198x)(CIL)(fr)(Disk 1 of 2)[cr A.B.C.].dsk" offset="0" sha1="58ca63f124e00f14b8bbd3c0f82faaaa" size="143360" /></dataarea></part></software>
+<software name="BeteduGecrA">
+<description>Bete du Gevaudan, La </description>
+<year>198x</year>
+<publisher>Disk 2 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c5b76ec4" name="Bete du Gevaudan, La (198x)(CIL)(fr)(Disk 2 of 2 Side A)[cr A.B.C.].dsk" offset="0" sha1="e568130eb0406affc6ccfeb86f7aa983" size="143360" /></dataarea></part></software>
+<software name="BeteduGecrA">
+<description>Bete du Gevaudan, La </description>
+<year>198x</year>
+<publisher>Disk 2 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bf45b03f" name="Bete du Gevaudan, La (198x)(CIL)(fr)(Disk 2 of 2 Side B)[cr A.B.C.].dsk" offset="0" sha1="6c6143889b756d1c4013436957d873d7" size="143360" /></dataarea></part></software>
+<software name="BeyondFlcrG">
+<description>Beyond Floppy </description>
+<year>19xx</year>
+<publisher>Greg Hale - Ted Cohn</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="474c3436" name="Beyond Floppy (19xx)(Greg Hale - Ted Cohn)[cr Great Lake Alliance].dsk" offset="0" sha1="eb3726086d2d7d693120a5e3ecc6adc6" size="143360" /></dataarea></part></software>
+<software name="BeyondZo">
+<description>Beyond Zork </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1524a4b3" name="Beyond Zork (1987)(Infocom)(Side A).dsk" offset="0" sha1="735170882ab4bc6e6390abddd8458d3d" size="143360" /></dataarea></part></software>
+<software name="BismarckcrD">
+<description>Bismarck </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8313ee35" name="Bismarck (1987)(Datasoft)[cr Digital Gang].dsk" offset="0" sha1="8c0512fe227d436ba3a652170d9be5e5" size="143360" /></dataarea></part></software>
+<software name="BlackCaucrB">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fa08d0c1" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 1 of 3 Side A)[cr Blade][b].dsk" offset="0" sha1="b21da518dcbd375a7d1f3ccebac70120" size="143360" /></dataarea></part></software>
+<software name="BlackCaucrD">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="51bc5da0" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 1 of 3 Side A)[cr Digital Gang][b].dsk" offset="0" sha1="e48d00342a916feac940b9b2b230773f" size="143360" /></dataarea></part></software>
+<software name="BlackCaucrD">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 1 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a2dd6af3" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 1 of 3 Side B)[cr Digital Gang][b].dsk" offset="0" sha1="8ecb35be4066cea48133d17ae7e67fbd" size="143360" /></dataarea></part></software>
+<software name="BlackCaucrD">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 2 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4725d5cb" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 2 of 3 Side A)[cr Digital Gang][b].dsk" offset="0" sha1="d14c95397c583e6938806769de01eab4" size="143360" /></dataarea></part></software>
+<software name="BlackCaucrD">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 2 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eedb8a2b" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 2 of 3 Side B)[cr Digital Gang][b].dsk" offset="0" sha1="3e510a3d9f081b86fea270fc280f4635" size="143360" /></dataarea></part></software>
+<software name="BlackCau">
+<description>Black Cauldron, The </description>
+<year>1985</year>
+<publisher>Disk 3 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="492719a1" name="Black Cauldron, The (1985)(Sierra - Walt Disney)(Disk 3 of 3 Side A).dsk" offset="0" sha1="3f4cff2de283f486c4c1caf637403dff" size="143360" /></dataarea></part></software>
+<software name="BlackMag">
+<description>Black Magic </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b4f3d2ef" name="Black Magic (1987)(Datasoft).dsk" offset="0" sha1="b2f2706629fbf84b980659d6535ced33" size="143360" /></dataarea></part></software>
+<software name="BlackMaga">
+<description>Black Magic </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e0fa1b65" name="Black Magic (1987)(Datasoft)[a].dsk" offset="0" sha1="83ffcd9cdf9af041b70a219b6c7f3966" size="143360" /></dataarea></part></software>
+<software name="BlackMagcrM">
+<description>Black Magic </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="56ee8dfb" name="Black Magic (1987)(Datasoft)[cr MindReader].dsk" offset="0" sha1="7cd67a9dd5ca47a2daf3cabd5830ff01" size="143360" /></dataarea></part></software>
+<software name="BombAlleRDO">
+<description>Bomb Alley </description>
+<year>19xx</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="782a8bbe" name="Bomb Alley (19xx)(SSI)[RDOS].dsk" offset="0" sha1="1cfc3d037287fc9761dff50d1e9615b9" size="143360" /></dataarea></part></software>
+<software name="Bop'nWrecrD">
+<description>Bop'n Wrestle </description>
+<year>1986</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="05a2e0e4" name="Bop'n Wrestle (1986)(Mindscape)[cr Digital Gang].dsk" offset="0" sha1="b07b434dda133378891882d591bd98e8" size="143360" /></dataarea></part></software>
+<software name="BorderZocrF">
+<description>Border Zone </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="51364791" name="Border Zone (1987)(Infocom)(Side A)[cr First Class].dsk" offset="0" sha1="8720766a67005497b7f82f433d0c5236" size="143360" /></dataarea></part></software>
+<software name="BorderZocrF">
+<description>Border Zone </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8b40e36e" name="Border Zone (1987)(Infocom)(Side B)[cr First Class].dsk" offset="0" sha1="cc3e518287c9e8c83623bee28cb90a28" size="143360" /></dataarea></part></software>
+<software name="BoulderDcrA">
+<description>Boulder Dash </description>
+<year>1984</year>
+<publisher>MicroLab</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b5220abf" name="Boulder Dash (1984)(MicroLab)[cr Association of Broadcasting Crackers].dsk" offset="0" sha1="f46dc16c961cf811a3c308872d083993" size="143360" /></dataarea></part></software>
+<software name="BreakthrRDO">
+<description>Breakthrough in the Ardennes v1.1 </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e84f1d59" name="Breakthrough in the Ardennes v1.1 (1984)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="3b473983958797d62e0b93f327467b22" size="143360" /></dataarea></part></software>
+<software name="BreakthrRDO">
+<description>Breakthrough in the Ardennes v1.1 </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7c71b30b" name="Breakthrough in the Ardennes v1.1 (1984)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="b3ad64d1910ff56b37003103e0f79063" size="143360" /></dataarea></part></software>
+<software name="BruceLeecrB">
+<description>Bruce Lee </description>
+<year>1984</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="11b3b0cc" name="Bruce Lee (1984)(Datasoft)[cr Black Bag].dsk" offset="0" sha1="10f31fba495bc45082e05856a3e90720" size="143360" /></dataarea></part></software>
+<software name="BruceLeecrB">
+<description>Bruce Lee </description>
+<year>1984</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8a5c4230" name="Bruce Lee (1984)(Datasoft)[cr Black Bag][a].dsk" offset="0" sha1="df1288e1f9a510520e49ea550b4540bd" size="143360" /></dataarea></part></software>
+<software name="BubbleBo">
+<description>Bubble Bobble </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2982842c" name="Bubble Bobble (1988)(Taito - Novalogic)(Side A).dsk" offset="0" sha1="15e4c18e861c9962fa6a70c61e1d9c18" size="143360" /></dataarea></part></software>
+<software name="BubbleBocrB">
+<description>Bubble Bobble </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b9e259af" name="Bubble Bobble (1988)(Taito - Novalogic)(Side A)[cr Blade].dsk" offset="0" sha1="744c099b5cd667dc31af273986f5a482" size="143360" /></dataarea></part></software>
+<software name="BubbleBocrC">
+<description>Bubble Bobble </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ec39dae6" name="Bubble Bobble (1988)(Taito - Novalogic)(Side A)[cr Club 96].dsk" offset="0" sha1="853a89ebc50a062303082589a58f999b" size="143360" /></dataarea></part></software>
+<software name="BubbleBo">
+<description>Bubble Bobble </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5efacf8b" name="Bubble Bobble (1988)(Taito - Novalogic)(Side B).dsk" offset="0" sha1="40d1c3735f7f75852f308a80654858e3" size="143360" /></dataarea></part></software>
+<software name="BubbleBocrC">
+<description>Bubble Bobble </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac056c8d" name="Bubble Bobble (1988)(Taito - Novalogic)(Side B)[cr Club 96].dsk" offset="0" sha1="ab225bed953a224be668e56adf4e635f" size="143360" /></dataarea></part></software>
+<software name="BureaucrcrC">
+<description>Bureaucracy </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bd4aaefc" name="Bureaucracy (1987)(Infocom)(Disk 1 of 2 Side A)[cr Coast to Coast].dsk" offset="0" sha1="1d319b938ff6ec8a212b40eb7fbf87cd" size="143360" /></dataarea></part></software>
+<software name="BureaucrcrC">
+<description>Bureaucracy </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="17ac362a" name="Bureaucracy (1987)(Infocom)(Disk 1 of 2 Side A)[cr Coast to Coast][a].dsk" offset="0" sha1="dead9c3db25bc379eb13d9754aaa1245" size="143360" /></dataarea></part></software>
+<software name="BureaucrcrC">
+<description>Bureaucracy </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aee5af63" name="Bureaucracy (1987)(Infocom)(Disk 1 of 2 Side B)[cr Coast to Coast].dsk" offset="0" sha1="2e03622ff7de5596576fb06633628454" size="143360" /></dataarea></part></software>
+<software name="BureaucrcrC">
+<description>Bureaucracy </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="306b685e" name="Bureaucracy (1987)(Infocom)(Disk 1 of 2 Side B)[cr Coast to Coast][a].dsk" offset="0" sha1="b47c1739368d181df98c17df662887cb" size="143360" /></dataarea></part></software>
+<software name="BureaucrcrC">
+<description>Bureaucracy </description>
+<year>1987</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="13e33e16" name="Bureaucracy (1987)(Infocom)(Disk 2 of 2)[cr Coast to Coast][DOS].dsk" offset="0" sha1="3b919066199a9992189701c5c50a549f" size="143360" /></dataarea></part></software>
+<software name="CaliforncrD">
+<description>California Games </description>
+<year>1987</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aa79dd97" name="California Games (1987)(Epyx)(Disk 1 of 2)[cr Digital Gang].dsk" offset="0" sha1="3ff1dd57b74ce50b73d811da99f2e8d9" size="143360" /></dataarea></part></software>
+<software name="CaliforncrD">
+<description>California Games </description>
+<year>1987</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="45e24a4e" name="California Games (1987)(Epyx)(Disk 2 of 2)[cr Digital Gang].dsk" offset="0" sha1="047b9b73f3fb296e7954d4836654c09d" size="143360" /></dataarea></part></software>
+<software name="CaptainGcrB">
+<description>Captain Goodnight </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="63d78c79" name="Captain Goodnight (1985)(Broderbund)(Side A)[cr Black Bag].dsk" offset="0" sha1="0f5c103496f49f821a62c2adcd425b59" size="143360" /></dataarea></part></software>
+<software name="CaptainGcrB">
+<description>Captain Goodnight </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0402ce3b" name="Captain Goodnight (1985)(Broderbund)(Side B)[cr Black Bag].dsk" offset="0" sha1="18cf42ac4f86dc2864a1577fc54364a2" size="143360" /></dataarea></part></software>
+<software name="CardShar">
+<description>Card Sharks </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac9df4a7" name="Card Sharks (1988)(Sharedata)(Side A).dsk" offset="0" sha1="d690792108e79077dc2a83e93673a433" size="143360" /></dataarea></part></software>
+<software name="CardShar">
+<description>Card Sharks </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f9f2c584" name="Card Sharks (1988)(Sharedata)(Side B).dsk" offset="0" sha1="0f5ca2c5c7faa6978eb19ad0922a159a" size="143360" /></dataarea></part></software>
+<software name="CarrierFRDO">
+<description>Carrier Force </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="419becb4" name="Carrier Force (1983)(SSI)[RDOS].dsk" offset="0" sha1="6097b6d078e0e56172f869f3ad39fb62" size="143360" /></dataarea></part></software>
+<software name="CarrierscrB">
+<description>Carriers at War v1.1 </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b01fbb52" name="Carriers at War v1.1 (1984)(SSG)(Disk 1 of 2)[cr Black Bag].dsk" offset="0" sha1="2b0f7fef2970a5d5963eadbb3519298f" size="143360" /></dataarea></part></software>
+<software name="CarrierscrB">
+<description>Carriers at War v1.1 </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="96f3737c" name="Carriers at War v1.1 (1984)(SSG)(Disk 2 of 2)[cr Black Bag].dsk" offset="0" sha1="abceffa8ff5bf6f76d9cea562c7870d8" size="143360" /></dataarea></part></software>
+<software name="Cartels&amp;RDO">
+<description>Cartels &amp; Cutthroats </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d306a513" name="Cartels &amp; Cutthroats (1981)(SSI)[RDOS].dsk" offset="0" sha1="6036643dd78d93f87d40c588465b0516" size="143360" /></dataarea></part></software>
+<software name="CastleSmcr">
+<description>Castle Smurfenstein </description>
+<year>1981</year>
+<publisher>Dead Smurf</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="641b9757" name="Castle Smurfenstein (1981)(Dead Smurf)[cr].dsk" offset="0" sha1="e37610ab4b77285349078c36ab4c63aa" size="143360" /></dataarea></part></software>
+<software name="Cavernso">
+<description>Caverns of Callisto </description>
+<year>19xx</year>
+<publisher>Chuckles</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8a79f37a" name="Caverns of Callisto (19xx)(Chuckles).dsk" offset="0" sha1="6e4c0a62fa07241d09fdab895cc7d364" size="143360" /></dataarea></part></software>
+<software name="CavernsocrM">
+<description>Caverns of Callisto </description>
+<year>19xx</year>
+<publisher>Chuckles</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dbcda767" name="Caverns of Callisto (19xx)(Chuckles)[cr Midwest Pirates Guild].dsk" offset="0" sha1="9c71f2cc16633525b447a8433ef10c90" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Disk 1 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8ba4e046" name="Centauri Alliance, The (198x)(Broderbund)(Disk 1 of 6).dsk" offset="0" sha1="674bb5c94c9ebb1bf0c17dce9a2f7f6a" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Rooster</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6c81be1d" name="Centauri Alliance, The (198x)(Broderbund)(Disk 2 of 6)(Rooster).dsk" offset="0" sha1="f04a888dc82706f1dc17a43d4c3a790c" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Scenario 1</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4d026cd8" name="Centauri Alliance, The (198x)(Broderbund)(Disk 3 of 6)(Scenario 1).dsk" offset="0" sha1="3906b007623ae6b6602e9a40eaf27320" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Scenario 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0d976331" name="Centauri Alliance, The (198x)(Broderbund)(Disk 4 of 6)(Scenario 2).dsk" offset="0" sha1="be12cdae0d5b1832bde78a4da8ab164c" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Scenario 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ed890de" name="Centauri Alliance, The (198x)(Broderbund)(Disk 5 of 6)(Scenario 3).dsk" offset="0" sha1="ee5737345ddb93a91f085773d6acb58b" size="143360" /></dataarea></part></software>
+<software name="Centauri">
+<description>Centauri Alliance, The </description>
+<year>198x</year>
+<publisher>Scenario 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e142d487" name="Centauri Alliance, The (198x)(Broderbund)(Disk 6 of 6)(Scenario 4).dsk" offset="0" sha1="4f06763dcca00ce9947c1145d543c234" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 1 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dd284f9f" name="Champions of Krynn (1990)(SSI)(Disk 1 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="0523149d9c2333889f719205c8eac944" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 1 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6d96c865" name="Champions of Krynn (1990)(SSI)(Disk 1 of 7)[RDOS].dsk" offset="0" sha1="1ef5bfe33b01e91d9326dfb5eac5037b" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 2 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e7774608" name="Champions of Krynn (1990)(SSI)(Disk 2 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="d64a7a4cf4cd5c289276c9ac9b3104d2" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 2 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9ed96722" name="Champions of Krynn (1990)(SSI)(Disk 2 of 7)[RDOS].dsk" offset="0" sha1="142d40a3c2ae52b00c642024772dd044" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 3 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b12fd59b" name="Champions of Krynn (1990)(SSI)(Disk 3 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="5f28b557bc1111df31ef937529fcd891" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 3 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fb112490" name="Champions of Krynn (1990)(SSI)(Disk 3 of 7)[RDOS].dsk" offset="0" sha1="58762a3bc42ac32a61aa7be8c26c4325" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 4 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e5f0ee27" name="Champions of Krynn (1990)(SSI)(Disk 4 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="ce9e3b00631b643a8dc8e2102e0a65c1" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 4 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="16626627" name="Champions of Krynn (1990)(SSI)(Disk 4 of 7)[RDOS].dsk" offset="0" sha1="47a175867e568be5ffa1abf27f8149a7" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 5 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2465ff6f" name="Champions of Krynn (1990)(SSI)(Disk 5 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="fe9778dcafa5098b2af8ad5a1802e4b0" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 5 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3580321b" name="Champions of Krynn (1990)(SSI)(Disk 5 of 7)[RDOS].dsk" offset="0" sha1="83788cc9e326acca57ff16d6d56fb358" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 6 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="52a44fd4" name="Champions of Krynn (1990)(SSI)(Disk 6 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="af521c3d71e33d0c34917566d6df8791" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 6 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a969fa63" name="Champions of Krynn (1990)(SSI)(Disk 6 of 7)[RDOS].dsk" offset="0" sha1="cda80881d42712d1b805f33d871816c5" size="143360" /></dataarea></part></software>
+<software name="ChampioncrE">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 7 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6d3455ad" name="Champions of Krynn (1990)(SSI)(Disk 7 of 7)[cr ECC][RDOS].dsk" offset="0" sha1="d77af6cbfada2fa4a8c68d2d24790e24" size="143360" /></dataarea></part></software>
+<software name="ChampionRDO">
+<description>Champions of Krynn </description>
+<year>1990</year>
+<publisher>Disk 7 of 7</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d564cc9d" name="Champions of Krynn (1990)(SSI)(Disk 7 of 7)[RDOS].dsk" offset="0" sha1="44671c71011bba7f9a7e51aae4505e38" size="143360" /></dataarea></part></software>
+<software name="ChampioncrC">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9e6a0f09" name="Championship Lode Runner (1984)(Broderbund)[cr Club 68000 - Hi-Res Hijackers].dsk" offset="0" sha1="3a5437f113cecc10c8fb01e9936f281e" size="143360" /></dataarea></part></software>
+<software name="ChampioncrC">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3b42a752" name="Championship Lode Runner (1984)(Broderbund)[cr Club 68000 - Hi-Res Hijackers][a2].dsk" offset="0" sha1="880d134b94344fc17b163a77bb3bf029" size="143360" /></dataarea></part></software>
+<software name="ChampioncrC">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fc3600b6" name="Championship Lode Runner (1984)(Broderbund)[cr Club 68000 - Hi-Res Hijackers][a].dsk" offset="0" sha1="ab107bc80ca15702406900ebf4eabe98" size="143360" /></dataarea></part></software>
+<software name="ChampioncrM">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="25f99032" name="Championship Lode Runner (1984)(Broderbund)[cr Midwest Pirates Guild].dsk" offset="0" sha1="6de66355368e607351d7c65001f542bd" size="143360" /></dataarea></part></software>
+<software name="ChampioncrM">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="6499a9ca" name="Championship Lode Runner (1984)(Broderbund)[cr Midwest Pirates Guild][o].dsk" offset="0" sha1="399e3f3c9a3ddd094349213f5d4c5692" size="143488" /></dataarea></part></software>
+<software name="ChampioncrM">
+<description>Championship Lode Runner </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="9eebef1b" name="Championship Lode Runner (1984)(Broderbund)[cr Midwest Pirates Guild][o][a].dsk" offset="0" sha1="8ee28b1511f9be3524da2f4b32406351" size="143488" /></dataarea></part></software>
+<software name="Chessv7.crC">
+<description>Chess v7.0 </description>
+<year>1982</year>
+<publisher>Odesta</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f3c443ea" name="Chess v7.0 (1982)(Odesta)[cr Clean Crack Band].dsk" offset="0" sha1="7268dfc1de1b67708a52b94e7b2e4953" size="143360" /></dataarea></part></software>
+<software name="Chipwits">
+<description>Chipwits </description>
+<year>1985</year>
+<publisher>Brainpower</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="46d6539f" name="Chipwits (1985)(Brainpower).dsk" offset="0" sha1="1ccbe9d7f7cc5720a5284854958bb368" size="143360" /></dataarea></part></software>
+<software name="Chivalry">
+<description>Chivalry </description>
+<year>1983</year>
+<publisher>Optimum Resource</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="acf174c5" name="Chivalry (1983)(Optimum Resource).dsk" offset="0" sha1="2dc12377e8920ebf09ee498abb670ddd" size="143360" /></dataarea></part></software>
+<software name="Chivalrya">
+<description>Chivalry </description>
+<year>1983</year>
+<publisher>Optimum Resource</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="090d95b1" name="Chivalry (1983)(Optimum Resource)[a].dsk" offset="0" sha1="34622453f9526dd1249964384dbd4302" size="143360" /></dataarea></part></software>
+<software name="Computera">
+<description>Computer Air Combat </description>
+<year>1980</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5c976fd3" name="Computer Air Combat (1980)(SSI)[a][RDOS].dsk" offset="0" sha1="7d65f2116f21bb8164c2c55619f9a686" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Air Combat </description>
+<year>1980</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4c74afb8" name="Computer Air Combat (1980)(SSI)[RDOS].dsk" offset="0" sha1="95eb2b4fc0e8b12ef75caed878bb65bc" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Air Combat - New Aircraft </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b9cc9435" name="Computer Air Combat - New Aircraft (19xx)(-)[RDOS].dsk" offset="0" sha1="c53d38f371a8a7a49f631ec7c1da5d96" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Ambush </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aff72cc4" name="Computer Ambush (1982)(SSI)[RDOS].dsk" offset="0" sha1="d96a36eb110b08be3e9d3e6633195025" size="143360" /></dataarea></part></software>
+<software name="ComputercrM">
+<description>Computer Baseball </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="121bc26b" name="Computer Baseball (1981)(SSI)[cr Mr. Krac-Man][RDOS].dsk" offset="0" sha1="c42e966d504ff04ebd1848d757e3a1e3" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Baseball </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4daeaddc" name="Computer Baseball (1981)(SSI)[RDOS].dsk" offset="0" sha1="3db79284b51428b99ab6a6a9814f31b6" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Bismarck </description>
+<year>1980</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="32d235fa" name="Computer Bismarck (1980)(SSI)[RDOS].dsk" offset="0" sha1="7c6bc9482e7485a2ed19c8fd9e1b426b" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Conflict </description>
+<year>1980</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dbbcfd1b" name="Computer Conflict (1980)(SSI)[RDOS].dsk" offset="0" sha1="041b435bb6ca1474da4b42323a52fbed" size="143360" /></dataarea></part></software>
+<software name="ComputerRDO">
+<description>Computer Quarterback </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="17eee33e" name="Computer Quarterback (1981)(SSI)[RDOS].dsk" offset="0" sha1="4618f2cdbda2bf5519efcb31af152a5a" size="143360" /></dataarea></part></software>
+<software name="Conan">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ba4e7d25" name="Conan (1984)(Datasoft)(Side A).dsk" offset="0" sha1="cd75d98c5f9d955060329e281d06b137" size="143360" /></dataarea></part></software>
+<software name="Conana">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="17078202" name="Conan (1984)(Datasoft)(Side A)[a].dsk" offset="0" sha1="c6e16999682d2703f134de66f22bd568" size="143360" /></dataarea></part></software>
+<software name="ConancrP">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="76a6a9d0" name="Conan (1984)(Datasoft)(Side A)[cr PPG].dsk" offset="0" sha1="4cd4c357d15874d29b0cebc4bbf85826" size="143360" /></dataarea></part></software>
+<software name="ConancrP">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2d77bec3" name="Conan (1984)(Datasoft)(Side A)[cr PPG][a2].dsk" offset="0" sha1="e1be4c4925c4b26efa51f57c4440c4a0" size="143360" /></dataarea></part></software>
+<software name="ConancrP">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="056462b0" name="Conan (1984)(Datasoft)(Side A)[cr PPG][a].dsk" offset="0" sha1="d9c7f6a006fc9c9c9cf697283faa96c6" size="143360" /></dataarea></part></software>
+<software name="Conan">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ad31dcec" name="Conan (1984)(Datasoft)(Side B).dsk" offset="0" sha1="5102d07d7e145b1fa67812a80783dfb6" size="143360" /></dataarea></part></software>
+<software name="ConancrP">
+<description>Conan </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac0bb87a" name="Conan (1984)(Datasoft)(Side B)[cr PPG].dsk" offset="0" sha1="99b0afa67595bb85a02faf7ff4a14fe4" size="143360" /></dataarea></part></software>
+<software name="CongoBoncr1">
+<description>Congo Bongo </description>
+<year>1983</year>
+<publisher>Sega</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="626f36d7" name="Congo Bongo (1983)(Sega)[cr 1200 Club - Midwest Pirates Guild].dsk" offset="0" sha1="1abda0eab123e418041902abb562f40d" size="143360" /></dataarea></part></software>
+<software name="CosmicBaRDO">
+<description>Cosmic Balance 2, The </description>
+<year>1986</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="23196dff" name="Cosmic Balance 2, The (1986)(SSI)[RDOS].dsk" offset="0" sha1="0b062a73bc779be0373a0cc22809f9f2" size="143360" /></dataarea></part></software>
+<software name="CosmicBaRDO">
+<description>Cosmic Balance, The </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="52fa1280" name="Cosmic Balance, The (1982)(SSI)[RDOS].dsk" offset="0" sha1="b8491a6aa92d1c53b545cc4d95d882a0" size="143360" /></dataarea></part></software>
+<software name="CountdowcrC">
+<description>Countdown to Shutdown </description>
+<year>1985</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d5b2f897" name="Countdown to Shutdown (1985)(Activision)[cr Circle K].dsk" offset="0" sha1="8a8f464086813f0a6db5b64fee86afb6" size="143360" /></dataarea></part></software>
+<software name="CrackofD">
+<description>Crack of Doom </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="038b8afe" name="Crack of Doom (19xx)(-)(Side A).dsk" offset="0" sha1="d9026ec8015a03265f5ec3ff0aee13ba" size="143360" /></dataarea></part></software>
+<software name="CrackofD">
+<description>Crack of Doom </description>
+<year>19xx</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3e729939" name="Crack of Doom (19xx)(-)(Side B).dsk" offset="0" sha1="5f87961809b931d17f9a2e197d877d05" size="143360" /></dataarea></part></software>
+<software name="CranstoncrB">
+<description>Cranston Manor </description>
+<year>1981</year>
+<publisher>On-Line Systems</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ea3a97eb" name="Cranston Manor (1981)(On-Line Systems)[cr Black Bag].dsk" offset="0" sha1="5ff5db3c704195b326c62c4b6e5711a5" size="143360" /></dataarea></part></software>
+<software name="CrimeAndcrA">
+<description>Crime And Punishment </description>
+<year>1984</year>
+<publisher>Jack Kress - Graeme Newman</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="648cf551" name="Crime And Punishment (1984)(Jack Kress - Graeme Newman)[cr Apple Mafia].dsk" offset="0" sha1="420acf95c5bed7a0d304d6c49952e19f" size="143360" /></dataarea></part></software>
+<software name="CrimeduP">
+<description>Crime du Parking, Le v1.2 </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a7f3c5ef" name="Crime du Parking, Le v1.2 (1985)(Froggy Software)(fr)(Side A).dsk" offset="0" sha1="42a52d00cec45c284e3e1a929c43977f" size="143360" /></dataarea></part></software>
+<software name="CrimeduPa">
+<description>Crime du Parking, Le v1.2 </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="50261611" name="Crime du Parking, Le v1.2 (1985)(Froggy Software)(fr)(Side A)[a].dsk" offset="0" sha1="13ffcdf71898f704653dba2d3c57a14d" size="143360" /></dataarea></part></software>
+<software name="CrimeduP">
+<description>Crime du Parking, Le v1.2 </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="07043605" name="Crime du Parking, Le v1.2 (1985)(Froggy Software)(fr)(Side B).dsk" offset="0" sha1="2d0c0f1b7390c8b00f3c97a11ac066d1" size="143360" /></dataarea></part></software>
+<software name="CrimeduPa">
+<description>Crime du Parking, Le v1.2 </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="125576a7" name="Crime du Parking, Le v1.2 (1985)(Froggy Software)(fr)(Side B)[a].dsk" offset="0" sha1="0070b2c9cb179cbaea6e7a12a81f743d" size="143360" /></dataarea></part></software>
+<software name="CrisisMoo">
+<description>Crisis Mountain </description>
+<year>1982</year>
+<publisher>Synergistic Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="d62ef8de" name="Crisis Mountain (1982)(Synergistic Software)[o].dsk" offset="0" sha1="a57b93c046b59fb842b7cf8359c86082" size="143363" /></dataarea></part></software>
+<software name="CryptofM">
+<description>Crypt of Medea </description>
+<year>1983</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f51191fe" name="Crypt of Medea (1983)(Sir Tech).dsk" offset="0" sha1="75a586714a9f75efb3bd93af6afdcba5" size="143360" /></dataarea></part></software>
+<software name="CryptofMcrM">
+<description>Crypt of Medea </description>
+<year>1983</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="df0ad8e9" name="Crypt of Medea (1983)(Sir Tech)[cr Midwest Pirates Guild].dsk" offset="0" sha1="39656319e67107a4589ed0a89afcb2c4" size="143360" /></dataarea></part></software>
+<software name="CryptofMcrM">
+<description>Crypt of Medea </description>
+<year>1983</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="79345b55" name="Crypt of Medea (1983)(Sir Tech)[cr Midwest Pirates Guild][a].dsk" offset="0" sha1="4d65d57a56298093316ef68094a155d3" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 1 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4bf33f8d" name="Curse of the Azure Bonds (1989)(SSI)(Disk 1 of 8)[RDOS].dsk" offset="0" sha1="b92b237359a4951b71537300b05ea428" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 2 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b4ccd3ab" name="Curse of the Azure Bonds (1989)(SSI)(Disk 2 of 8)[RDOS].dsk" offset="0" sha1="48491d377f1fe7c3fa30ed565bfb8ac0" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 3 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="316faf52" name="Curse of the Azure Bonds (1989)(SSI)(Disk 3 of 8)[RDOS].dsk" offset="0" sha1="0f3a55294610dfa91e7092de6527ad1a" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 4 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="852f2679" name="Curse of the Azure Bonds (1989)(SSI)(Disk 4 of 8)[RDOS].dsk" offset="0" sha1="f143bcd37ddde854f0326510cefe818a" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 5 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="acaa41c7" name="Curse of the Azure Bonds (1989)(SSI)(Disk 5 of 8)[RDOS].dsk" offset="0" sha1="f923ded34d3c933787be03b28d96e52b" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 6 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5c625565" name="Curse of the Azure Bonds (1989)(SSI)(Disk 6 of 8)[RDOS].dsk" offset="0" sha1="05097f888c81868f4bb5c4f0b732dba6" size="143360" /></dataarea></part></software>
+<software name="CurseoftRDO">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Disk 7 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="783c8ece" name="Curse of the Azure Bonds (1989)(SSI)(Disk 7 of 8)[RDOS].dsk" offset="0" sha1="c12ca7ca8c365f977da3e04a9c43b8d5" size="143360" /></dataarea></part></software>
+<software name="Curseoft">
+<description>Curse of the Azure Bonds </description>
+<year>1989</year>
+<publisher>Save</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="82741289" name="Curse of the Azure Bonds (1989)(SSI)(Disk 8 of 8)(Save).dsk" offset="0" sha1="4894f03cb49a5403f7ed2dcbcd305d37" size="143360" /></dataarea></part></software>
+<software name="CutThroa">
+<description>Cut Throats </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b084b498" name="Cut Throats (1984)(Infocom).dsk" offset="0" sha1="89357f0d8a50b6040806de096782457f" size="143360" /></dataarea></part></software>
+<software name="CytronMab">
+<description>Cytron Masters </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3b97f8d7" name="Cytron Masters (1982)(SSI)[b][RDOS].dsk" offset="0" sha1="78be312c0fb77f734f6ff865529e3647" size="143360" /></dataarea></part></software>
+<software name="DallasQu">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a527682f" name="Dallas Quest, The (1984)(Datasoft)(Side A).dsk" offset="0" sha1="882578b7686e2425ebf560c4ee62a887" size="143360" /></dataarea></part></software>
+<software name="DallasQua">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e2f79f7e" name="Dallas Quest, The (1984)(Datasoft)(Side A)[a].dsk" offset="0" sha1="dff784f85739fedb4472c399302b574c" size="143360" /></dataarea></part></software>
+<software name="DallasQucrR">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2ee94393" name="Dallas Quest, The (1984)(Datasoft)(Side A)[cr Racketeers].dsk" offset="0" sha1="dfe00cac1bb7917ba61952fb0ed80fe4" size="143360" /></dataarea></part></software>
+<software name="DallasQu">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9812713d" name="Dallas Quest, The (1984)(Datasoft)(Side B).dsk" offset="0" sha1="4a60d5e81dfd6aea113024dd008a439c" size="143360" /></dataarea></part></software>
+<software name="DallasQua">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e5ed897" name="Dallas Quest, The (1984)(Datasoft)(Side B)[a].dsk" offset="0" sha1="3a58636e344ee4a6bd2ef2e2fe4e12d6" size="143360" /></dataarea></part></software>
+<software name="DallasQucrR">
+<description>Dallas Quest, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8761d896" name="Dallas Quest, The (1984)(Datasoft)(Side B)[cr Racketeers].dsk" offset="0" sha1="43360ea860c86215c18500ea5c73024a" size="143360" /></dataarea></part></software>
+<software name="DarkCrysDOS">
+<description>Dark Crystal, The </description>
+<year>1982</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="75615733" name="Dark Crystal, The (1982)(Sierra)(Disk 1 of 3 Side A)[DOS].dsk" offset="0" sha1="908d77c371c8354e99851f9329738ebc" size="143360" /></dataarea></part></software>
+<software name="DarkCrys">
+<description>Dark Crystal, The </description>
+<year>1982</year>
+<publisher>Disk 1 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c8d13cfe" name="Dark Crystal, The (1982)(Sierra)(Disk 1 of 3 Side B).dsk" offset="0" sha1="3669f1179d7ee944f0b0759ceff458ed" size="143360" /></dataarea></part></software>
+<software name="DarkCrys">
+<description>Dark Crystal, The </description>
+<year>1982</year>
+<publisher>Disk 2 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cff95a61" name="Dark Crystal, The (1982)(Sierra)(Disk 2 of 3 Side A).dsk" offset="0" sha1="6962578f069dee60ad156dbd09d825b5" size="143360" /></dataarea></part></software>
+<software name="DarkCrys">
+<description>Dark Crystal, The </description>
+<year>1982</year>
+<publisher>Disk 2 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d50f9ca7" name="Dark Crystal, The (1982)(Sierra)(Disk 2 of 3 Side B).dsk" offset="0" sha1="a8b29d0fbdbea3f230ab181890d4528e" size="143360" /></dataarea></part></software>
+<software name="DarkCrys">
+<description>Dark Crystal, The </description>
+<year>1982</year>
+<publisher>Save</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3838c779" name="Dark Crystal, The (1982)(Sierra)(Disk 3 of 3)(Save).dsk" offset="0" sha1="6727ee206124d7d04e456eaa6f366fbc" size="143360" /></dataarea></part></software>
+<software name="DarkHearPAS">
+<description>Dark Heart of Uukrul, The </description>
+<year>1989</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b17440c5" name="Dark Heart of Uukrul, The (1989)(Broderbund)(Disk 1 of 4)[PASCAL].dsk" offset="0" sha1="bd986e9f8d9a407bcae13b0f01a606d9" size="143360" /></dataarea></part></software>
+<software name="DarkHearsce">
+<description>Dark Heart of Uukrul, The </description>
+<year>1989</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="85fc75fe" name="Dark Heart of Uukrul, The (1989)(Broderbund)(Disk 2 of 4)[scenario A][PASCAL].dsk" offset="0" sha1="40e8f8ca63a281f4093ec42f94b3fb50" size="143360" /></dataarea></part></software>
+<software name="DarkHearPAS">
+<description>Dark Heart of Uukrul, The </description>
+<year>1989</year>
+<publisher>Scenario B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9f88900c" name="Dark Heart of Uukrul, The (1989)(Broderbund)(Disk 3 of 4)(Scenario B)[PASCAL].dsk" offset="0" sha1="17269d56ebd25f182a2a516f0aefe691" size="143360" /></dataarea></part></software>
+<software name="DarkHearPAS">
+<description>Dark Heart of Uukrul, The </description>
+<year>1989</year>
+<publisher>Archive</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c20120f7" name="Dark Heart of Uukrul, The (1989)(Broderbund)(Disk 4 of 4)(Archive)[PASCAL].dsk" offset="0" sha1="ea28705ff2d3b7c6586d2c7cc5eff53a" size="143360" /></dataarea></part></software>
+<software name="DarkLordcr">
+<description>Dark Lord </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ff13eb9e" name="Dark Lord (1987)(Datasoft)(Side A)[cr].dsk" offset="0" sha1="88f08e15b02bc39c7fe06dfcfa9dabd0" size="143360" /></dataarea></part></software>
+<software name="DarkLordcr">
+<description>Dark Lord </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6b7bcdc4" name="Dark Lord (1987)(Datasoft)(Side B)[cr].dsk" offset="0" sha1="085006dace2af1e1785572cf51447db6" size="143360" /></dataarea></part></software>
+<software name="DawnPatrcrD">
+<description>Dawn Patrol </description>
+<year>1980</year>
+<publisher>TSR</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="535a3464" name="Dawn Patrol (1980)(TSR)[cr Disk Jockey - Krakowicz].dsk" offset="0" sha1="6aaca6f2713a5c2f118c1312c4994c89" size="143360" /></dataarea></part></software>
+<software name="DeadLine">
+<description>Dead Line </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4c6af71a" name="Dead Line (1982)(Infocom).dsk" offset="0" sha1="6f404ff03cd719bb04782046925161bf" size="143360" /></dataarea></part></software>
+<software name="DeadLinePAS">
+<description>Dead Line </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="de63dff9" name="Dead Line (1982)(Infocom)[PASCAL].dsk" offset="0" sha1="8c3caaff1eea659330fa5a457eb109d4" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrB">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Disk 1 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9b4bdb51" name="Deathlord (1987)(Electronic Arts)(Disk 1 of 5)[cr Blade].dsk" offset="0" sha1="c8e1bc0327c4a78c40008a787d5486a5" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Disk 1 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="44fb3f7f" name="Deathlord (1987)(Electronic Arts)(Disk 1 of 5)[cr Digital Gang].dsk" offset="0" sha1="0d2ee7fc35e141bdf07f151e0baa2f81" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Disk 1 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2269cdd4" name="Deathlord (1987)(Electronic Arts)(Disk 1 of 5)[cr Digital Gang][b].dsk" offset="0" sha1="8668cad2e1b958d726e8ccc87c98537e" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Master Scenario A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b3d0d9ea" name="Deathlord (1987)(Electronic Arts)(Disk 2 of 5)(Master Scenario A)[cr Digital Gang].dsk" offset="0" sha1="929043d73104da070da7930e948ebadc" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Master Scenario A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="177d7254" name="Deathlord (1987)(Electronic Arts)(Disk 2 of 5)(Master Scenario A)[cr Digital Gang][b].dsk" offset="0" sha1="678e6a7869973bb3a0a4abae313cf77a" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Master Scenario B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d3735062" name="Deathlord (1987)(Electronic Arts)(Disk 3 of 5)(Master Scenario B)[cr Digital Gang].dsk" offset="0" sha1="0b48f8b91fbddf3a0e42aa68ded2103a" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Master Scenario B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22682e31" name="Deathlord (1987)(Electronic Arts)(Disk 3 of 5)(Master Scenario B)[cr Digital Gang][b].dsk" offset="0" sha1="2b84c8d6ac545f0fae5c861027a3878f" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrB">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Scenario A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="746b821f" name="Deathlord (1987)(Electronic Arts)(Disk 4 of 5)(Scenario A)[cr Blade].dsk" offset="0" sha1="296edb81828f2f181d80229f8f7c6fda" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrD">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Scenario A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ca5d95c" name="Deathlord (1987)(Electronic Arts)(Disk 4 of 5)(Scenario A)[cr Digital Gang][b].dsk" offset="0" sha1="eb9eb809b307f86fe05dd85875eb10b0" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrB">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Disk 4 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bac303c0" name="Deathlord (1987)(Electronic Arts)(Disk 4 of 5)[cr Blade].dsk" offset="0" sha1="41130d1636e32749a1850c3fe624c16a" size="143360" /></dataarea></part></software>
+<software name="DeathlorcrB">
+<description>Deathlord </description>
+<year>1987</year>
+<publisher>Scenario B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ae00c497" name="Deathlord (1987)(Electronic Arts)(Disk 5 of 5)(Scenario B)[cr Blade].dsk" offset="0" sha1="3f54146bfa5830ff1cb2745f37edd5d7" size="143360" /></dataarea></part></software>
+<software name="Demon'sWcr">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fad547ea" name="Demon's Winter (1988)(SSI)(Disk 1 of 4)[cr][RDOS].dsk" offset="0" sha1="16c9f1bfdabbee90a3f83973e037a024" size="143360" /></dataarea></part></software>
+<software name="Demon'sWRDO">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b33ca2b2" name="Demon's Winter (1988)(SSI)(Disk 1 of 4)[RDOS].dsk" offset="0" sha1="014531c36930b0895b84bc1a41c4f64e" size="143360" /></dataarea></part></software>
+<software name="Demon'sW">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="61b1f732" name="Demon's Winter (1988)(SSI)(Disk 2 of 4).dsk" offset="0" sha1="24fb9c0794e93c07367151e2991b133a" size="143360" /></dataarea></part></software>
+<software name="Demon'sWcr">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="de718ba0" name="Demon's Winter (1988)(SSI)(Disk 2 of 4)[cr].dsk" offset="0" sha1="c284844999e427d1aa84ba68d00d6605" size="143360" /></dataarea></part></software>
+<software name="Demon'sW">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6aca34a9" name="Demon's Winter (1988)(SSI)(Disk 3 of 4).dsk" offset="0" sha1="f4a72b78cf89a194f4429d508cf86614" size="143360" /></dataarea></part></software>
+<software name="Demon'sWcr">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="364aa84f" name="Demon's Winter (1988)(SSI)(Disk 3 of 4)[cr].dsk" offset="0" sha1="b53c13f31bfc569e7c3cb70a9e4029ab" size="143360" /></dataarea></part></software>
+<software name="Demon'sW">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2f333066" name="Demon's Winter (1988)(SSI)(Disk 4 of 4).dsk" offset="0" sha1="17079619745bf86442a024a0c1e621f5" size="143360" /></dataarea></part></software>
+<software name="Demon'sWcr">
+<description>Demon's Winter </description>
+<year>1988</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc6aa686" name="Demon's Winter (1988)(SSI)(Disk 4 of 4)[cr].dsk" offset="0" sha1="75e086c4da9cd8a58ab2d36af219bfae" size="143360" /></dataarea></part></software>
+<software name="DesecratcrM">
+<description>Desecration, The </description>
+<year>19xx</year>
+<publisher>Mind Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5dee9a8c" name="Desecration, The (19xx)(Mind Games)[cr Mr. Krac-Man].dsk" offset="0" sha1="7fe6c868776604469fece39192cd6aed" size="143360" /></dataarea></part></software>
+<software name="Destroye">
+<description>Destroyer </description>
+<year>1986</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4a7d1197" name="Destroyer (1986)(Epyx).dsk" offset="0" sha1="79f8d049f7e89a4ccc1698ffe48eaa5a" size="143360" /></dataarea></part></software>
+<software name="DestroyecrC">
+<description>Destroyer </description>
+<year>1986</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b510e528" name="Destroyer (1986)(Epyx)[cr Coast to Coast].dsk" offset="0" sha1="8656b12314b9659fdb3f536b71f1e655" size="143360" /></dataarea></part></software>
+<software name="DinoSmurcrC">
+<description>Dino Smurf </description>
+<year>19xx</year>
+<publisher>Dead Smurf</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="42f44d68" name="Dino Smurf (19xx)(Dead Smurf)[cr Carl Sagan].dsk" offset="0" sha1="8cc756c32564727f13b81e9777e92df6" size="143360" /></dataarea></part></software>
+<software name="DiveBombcr6">
+<description>Dive Bomber </description>
+<year>1988</year>
+<publisher>Acme Animation</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="13c33f66" name="Dive Bomber (1988)(Acme Animation)[cr 6502 Crew].dsk" offset="0" sha1="2caa01dac999fb03c64c82db1ab3a366" size="143360" /></dataarea></part></software>
+<software name="DonkeyKo">
+<description>Donkey Kong </description>
+<year>1983</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="99d02b9b" name="Donkey Kong (1983)(Atari).dsk" offset="0" sha1="a3bcfbb732ad5a21d95b909d7bf17a23" size="143360" /></dataarea></part></software>
+<software name="DonkeyKoa">
+<description>Donkey Kong </description>
+<year>1983</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0deda28e" name="Donkey Kong (1983)(Atari)[a].dsk" offset="0" sha1="76b82e3a3cca67441332a65528888d5e" size="143360" /></dataarea></part></software>
+<software name="DonkeyKocrF">
+<description>Donkey Kong </description>
+<year>1983</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="c87a45b1" name="Donkey Kong (1983)(Atari)[cr Freeze][o].dsk" offset="0" sha1="733fcd19937d24595044ad0165a3d431" size="143363" /></dataarea></part></software>
+<software name="Drol">
+<description>Drol </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="328cb899" name="Drol (1983)(Broderbund).dsk" offset="0" sha1="77849b129d63a693a7cebbcd36a236aa" size="143360" /></dataarea></part></software>
+<software name="DrolcrA">
+<description>Drol </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b3824b7f" name="Drol (1983)(Broderbund)[cr Apple Bandit].dsk" offset="0" sha1="db82e1b1a132bc9f478f1b90b315dbd2" size="143360" /></dataarea></part></software>
+<software name="DungeonMcr">
+<description>Dungeon Master Assistant Vol. I - Encounters </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="67e1fc57" name="Dungeon Master Assistant Vol. I - Encounters (1988)(SSI)(Disk 1 of 4)[cr][RDOS].dsk" offset="0" sha1="c519c37ee8fc1de03f718767b274c817" size="143360" /></dataarea></part></software>
+<software name="DungeonMRDO">
+<description>Dungeon Master Assistant Vol. I - Encounters </description>
+<year>1988</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8973e18f" name="Dungeon Master Assistant Vol. I - Encounters (1988)(SSI)(Disk 1 of 4)[RDOS].dsk" offset="0" sha1="583234bbc4a6018f87425e40c6a2a05c" size="143360" /></dataarea></part></software>
+<software name="DungeonM">
+<description>Dungeon Master Assistant Vol. I - Encounters </description>
+<year>1988</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fafa454c" name="Dungeon Master Assistant Vol. I - Encounters (1988)(SSI)(Disk 2 of 4).dsk" offset="0" sha1="62f81dacb7f36e4c691f7dec25043d71" size="143360" /></dataarea></part></software>
+<software name="DungeonMRDO">
+<description>Dungeon Master Assistant Vol. I - Encounters </description>
+<year>1988</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ae868e50" name="Dungeon Master Assistant Vol. I - Encounters (1988)(SSI)(Disk 3 of 4)[RDOS].dsk" offset="0" sha1="8128e7c34d72ad5480b3d8ff81f9c466" size="143360" /></dataarea></part></software>
+<software name="DungeonM">
+<description>Dungeon Master Assistant Vol. I - Encounters </description>
+<year>1988</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc34fc22" name="Dungeon Master Assistant Vol. I - Encounters (1988)(SSI)(Disk 4 of 4).dsk" offset="0" sha1="b2ad07f60146bc42c2997689acc9e03d" size="143360" /></dataarea></part></software>
+<software name="EaglesRDO">
+<description>Eagles </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d6f42783" name="Eagles (1983)(SSI)[RDOS].dsk" offset="0" sha1="bc1827c741bdf560325a56699e46e8b9" size="143360" /></dataarea></part></software>
+<software name="Eamon060">
+<description>Eamon 060 - The Sewers of Chicago </description>
+<year>1989</year>
+<publisher>J. Allen</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="96f18c3a" name="Eamon 060 - The Sewers of Chicago (1989)(J. Allen).dsk" offset="0" sha1="4234c0690252f7928a68fa6722639ed1" size="143360" /></dataarea></part></software>
+<software name="Eamon061">
+<description>Eamon 061 - The Harpy Cloud </description>
+<year>1986</year>
+<publisher>A. Forter</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2f437cc4" name="Eamon 061 - The Harpy Cloud (1986)(A. Forter).dsk" offset="0" sha1="8fe57df6fe946f8063830f9759fbfe11" size="143360" /></dataarea></part></software>
+<software name="EarlWeav">
+<description>Earl Weaver Baseball </description>
+<year>1989</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="405e2a04" name="Earl Weaver Baseball (1989)(Mirage Graphics)(Side A).dsk" offset="0" sha1="5befc1f7cfeaf575daffa26c2621d38a" size="143360" /></dataarea></part></software>
+<software name="EarlWeav">
+<description>Earl Weaver Baseball </description>
+<year>1989</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="170c4b79" name="Earl Weaver Baseball (1989)(Mirage Graphics)(Side B).dsk" offset="0" sha1="732b9a0eb449dccd68ce7f17dbde6df3" size="143360" /></dataarea></part></software>
+<software name="EarthOrbcrB">
+<description>Earth Orbit Station </description>
+<year>1983</year>
+<publisher>Game</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c8eb8d70" name="Earth Orbit Station (1983)(Electronic Arts)(Disk 1 of 4)(Game)[cr Blade][DOS].dsk" offset="0" sha1="702e8fe43dd2ad3f2ffc38aecac05d2a" size="143360" /></dataarea></part></software>
+<software name="EarthOrbcrB">
+<description>Earth Orbit Station </description>
+<year>1983</year>
+<publisher>Mission Data</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="72f44938" name="Earth Orbit Station (1983)(Electronic Arts)(Disk 2 of 4)(Mission Data)[cr Blade].dsk" offset="0" sha1="4dbc8aac6d98f99fdcff50bc760d905a" size="143360" /></dataarea></part></software>
+<software name="EarthOrbcrB">
+<description>Earth Orbit Station </description>
+<year>1983</year>
+<publisher>Arch</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="870733af" name="Earth Orbit Station (1983)(Electronic Arts)(Disk 3 of 4)(Arch)[cr Blade].dsk" offset="0" sha1="e4d37f35435e081845548fe34772f97e" size="143360" /></dataarea></part></software>
+<software name="EarthOrbcrB">
+<description>Earth Orbit Station </description>
+<year>1983</year>
+<publisher>Mission</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="68a4fb0e" name="Earth Orbit Station (1983)(Electronic Arts)(Disk 4 of 4)(Mission)[cr Blade].dsk" offset="0" sha1="fa95d05054f0cccca95d68638ce312a9" size="143360" /></dataarea></part></software>
+<software name="EarthlyDPAS">
+<description>Earthly Delights </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e3e23b7" name="Earthly Delights (1984)(Datamost)(Side A)[PASCAL].dsk" offset="0" sha1="cf143c2ebb45563fe2dc02eb5e5be0ed" size="143360" /></dataarea></part></software>
+<software name="EarthlyDPAS">
+<description>Earthly Delights </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="13c93c1b" name="Earthly Delights (1984)(Datamost)(Side B)[PASCAL].dsk" offset="0" sha1="f90938922df31f6aee261c2b69463a8d" size="143360" /></dataarea></part></software>
+<software name="EidolonTcrD">
+<description>Eidolon, The </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="ce981c4a" name="Eidolon, The (1985)(Lucasfilm Games)[cr Digital Gang][o].dsk" offset="0" sha1="6c8758170cea2485ad34caa26b43f26e" size="143363" /></dataarea></part></software>
+<software name="ElysianF">
+<description>Elysian Fields, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b64bd153" name="Elysian Fields, The (1984)(American Eagle)(Side A).dsk" offset="0" sha1="c7de1baf6c1538d427878cd437a53383" size="143360" /></dataarea></part></software>
+<software name="ElysianFcrB">
+<description>Elysian Fields, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="203624db" name="Elysian Fields, The (1984)(American Eagle)(Side A)[cr Black Bag].dsk" offset="0" sha1="9511dcfd9e70d9670c3e32896bccfe6d" size="143360" /></dataarea></part></software>
+<software name="ElysianF">
+<description>Elysian Fields, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4c3a22f8" name="Elysian Fields, The (1984)(American Eagle)(Side B).dsk" offset="0" sha1="bf52c36af985946a6243f4f5a8e10229" size="143360" /></dataarea></part></software>
+<software name="ElysianFcrB">
+<description>Elysian Fields, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4ec34824" name="Elysian Fields, The (1984)(American Eagle)(Side B)[cr Black Bag].dsk" offset="0" sha1="cd2b75a3a7bf192a0920caeba8c0e3cd" size="143360" /></dataarea></part></software>
+<software name="Enchante">
+<description>Enchanter </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7259fcc8" name="Enchanter (1983)(Infocom).dsk" offset="0" sha1="131c1c0c4d35ca5b8dbe91acbaa47ae6" size="143360" /></dataarea></part></software>
+<software name="Enchantea">
+<description>Enchanter </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ab72359a" name="Enchanter (1983)(Infocom)[a].dsk" offset="0" sha1="13611c76f1be574bca3595d40e12bc17" size="143360" /></dataarea></part></software>
+<software name="EpidemicRDO">
+<description>Epidemic </description>
+<year>198x</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2e6944e0" name="Epidemic (198x)(SSI)[RDOS].dsk" offset="0" sha1="34a2bc72780e4399be40543383d71e5b" size="143360" /></dataarea></part></software>
+<software name="EscapecrD">
+<description>Escape </description>
+<year>1984</year>
+<publisher>Bantam</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1169670" name="Escape (1984)(Bantam)[cr Digital Gang].dsk" offset="0" sha1="4f96522a23ec18f4f023fb9345a158cf" size="143360" /></dataarea></part></software>
+<software name="EternalDRDO">
+<description>Eternal Dagger </description>
+<year>1987</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f28d4aba" name="Eternal Dagger (1987)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="2d3e8238b06c9e111e41032afb7bd1d2" size="143360" /></dataarea></part></software>
+<software name="EternalDRDO">
+<description>Eternal Dagger </description>
+<year>1987</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="146f615e" name="Eternal Dagger (1987)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="f7950bb421f8a5e0f95dfb5c961a780b" size="143360" /></dataarea></part></software>
+<software name="Evolutio">
+<description>Evolution </description>
+<year>1982</year>
+<publisher>Sydney Development</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c4e6b52b" name="Evolution (1982)(Sydney Development).dsk" offset="0" sha1="b5a99fe7eb633705189f6d87ab3b819f" size="143360" /></dataarea></part></software>
+<software name="Evolutioa">
+<description>Evolution </description>
+<year>1982</year>
+<publisher>Sydney Development</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="27c44a3f" name="Evolution (1982)(Sydney Development)[a].dsk" offset="0" sha1="4c3519c915467e640015585928233e74" size="143360" /></dataarea></part></software>
+<software name="Excalibu">
+<description>Excalibur Quest </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1e30d484" name="Excalibur Quest (19xx)(Excalibur)(fr)(Side A).dsk" offset="0" sha1="10949215d9e81e8fb76c10d300ab3e3a" size="143360" /></dataarea></part></software>
+<software name="ExcalibucrA">
+<description>Excalibur Quest </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a87b532d" name="Excalibur Quest (19xx)(Excalibur)(fr)(Side A)[cr A.B.C.][a].dsk" offset="0" sha1="acc20bf661c15f9ba1d65ed45ccbf1de" size="143360" /></dataarea></part></software>
+<software name="Excalibu">
+<description>Excalibur Quest </description>
+<year>19xx</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f902bbb8" name="Excalibur Quest (19xx)(Excalibur)(fr)(Side B).dsk" offset="0" sha1="19a6681a155e11ca6e6cd816491a34c9" size="143360" /></dataarea></part></software>
+<software name="F-15StricrB">
+<description>F-15 Strike Eagle </description>
+<year>1985</year>
+<publisher>Microprose</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143616">
+<rom crc="7c05a931" name="F-15 Strike Eagle (1985)(Microprose)[cr Black Bag][o].dsk" offset="0" sha1="4445e50e270d99296b6b3a56e5147f4b" size="143616" /></dataarea></part></software>
+<software name="F-15StricrB">
+<description>F-15 Strike Eagle </description>
+<year>1985</year>
+<publisher>Microprose</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="f61f40e3" name="F-15 Strike Eagle (1985)(Microprose)[cr Black Bag][o][a2].dsk" offset="0" sha1="60121f84093d9dcb16bc427f7febfd3f" size="143363" /></dataarea></part></software>
+<software name="F-15StricrB">
+<description>F-15 Strike Eagle </description>
+<year>1985</year>
+<publisher>Microprose</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="9250ca41" name="F-15 Strike Eagle (1985)(Microprose)[cr Black Bag][o][a].dsk" offset="0" sha1="7abdda10bc9f912230585ac1d43f8548" size="143363" /></dataarea></part></software>
+<software name="FatCity">
+<description>Fat City </description>
+<year>1983</year>
+<publisher>Richard Hefter - Steve Worthington</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0f14ac2f" name="Fat City (1983)(Richard Hefter - Steve Worthington).dsk" offset="0" sha1="184518ce9d7aabdf4796c5cbfa22c998" size="143360" /></dataarea></part></software>
+<software name="FatCitycrM">
+<description>Fat City </description>
+<year>1983</year>
+<publisher>Richard Hefter - Steve Worthington</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2f7035d8" name="Fat City (1983)(Richard Hefter - Steve Worthington)[cr Mr. Krac-Man].dsk" offset="0" sha1="e50f9d097cacc5fc39683f4e82132b46" size="143360" /></dataarea></part></software>
+<software name="FellowshcrF">
+<description>Fellowship of the Rings </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ba819c27" name="Fellowship of the Rings (1986)(-)(Disk 1 of 2)[cr First Class].dsk" offset="0" sha1="7173eeeee48059e682517f17da842c47" size="143360" /></dataarea></part></software>
+<software name="FellowshcrF">
+<description>Fellowship of the Rings </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8b798078" name="Fellowship of the Rings (1986)(-)(Disk 2 of 2)[cr First Class].dsk" offset="0" sha1="48aca502f773652fa5804d7ca62e767b" size="143360" /></dataarea></part></software>
+<software name="Fido">
+<description>Fido </description>
+<year>1982</year>
+<publisher>Pat Montelo</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22d039f2" name="Fido (1982)(Pat Montelo).dsk" offset="0" sha1="726ba86a01c727f416ac15664084c693" size="143360" /></dataarea></part></software>
+<software name="FieldofF">
+<description>Field of Fire </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d3e4c252" name="Field of Fire (19xx)(SSI)(Side A).dsk" offset="0" sha1="10ab7c62775c9fde55f259ae23045102" size="143360" /></dataarea></part></software>
+<software name="FieldofF">
+<description>Field of Fire </description>
+<year>19xx</year>
+<publisher>Scenario</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a75578a7" name="Field of Fire (19xx)(SSI)(Side B)(Scenario).dsk" offset="0" sha1="0b8b2513cd5b87cea2188154e8cdbdee" size="143360" /></dataarea></part></software>
+<software name="FiftyMisRDO">
+<description>Fifty Mission Crush </description>
+<year>1984</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dcf96149" name="Fifty Mission Crush (1984)(SSI)[RDOS].dsk" offset="0" sha1="4b38707f3c699cd9771a641281c07918" size="143360" /></dataarea></part></software>
+<software name="FightNigcrD">
+<description>Fight Night </description>
+<year>1985</year>
+<publisher>Accolade</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="02f72f1c" name="Fight Night (1985)(Accolade)[cr Digital Gang].dsk" offset="0" sha1="c1c8b6ebd4c52b18fdfd63ceb223e0fa" size="143360" /></dataarea></part></software>
+<software name="FightNigcrL">
+<description>Fight Night </description>
+<year>1985</year>
+<publisher>Accolade</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1f31e32f" name="Fight Night (1985)(Accolade)[cr Lot - The Mad Mechanic].dsk" offset="0" sha1="c311b9b1da51f8228ba519b167397835" size="143360" /></dataarea></part></software>
+<software name="FighterCRDO">
+<description>Fighter Command </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b617333a" name="Fighter Command (1983)(SSI)[RDOS].dsk" offset="0" sha1="009cfb3fe085e776ca56bf1c53b6965b" size="143360" /></dataarea></part></software>
+<software name="FlakcrM">
+<description>Flak </description>
+<year>1984</year>
+<publisher>Funsoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c06863b0" name="Flak (1984)(Funsoft)[cr Midwest Pirates Guild - 1200 Club].dsk" offset="0" sha1="5dddb0e647c16f633dc2cf0729cf078a" size="143360" /></dataarea></part></software>
+<software name="FlightSicrM">
+<description>Flight Simulator 1 </description>
+<year>1983</year>
+<publisher>subLOGIC</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e33f5e5f" name="Flight Simulator 1 (1983)(subLOGIC)[cr Midwest Pirates Guild].dsk" offset="0" sha1="bace5a7c1951df0a12949763e1fc15f5" size="143360" /></dataarea></part></software>
+<software name="FlightSicrB">
+<description>Flight Simulator II v1.0 </description>
+<year>1983</year>
+<publisher>subLOGIC</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="86ed6572" name="Flight Simulator II v1.0 (1983)(subLOGIC)[cr Brainware].dsk" offset="0" sha1="49832de2ed498ed46db774f8f26cbb26" size="143360" /></dataarea></part></software>
+<software name="FlightSicrM">
+<description>Flight Simulator II v1.0 </description>
+<year>1983</year>
+<publisher>subLOGIC</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="779320a2" name="Flight Simulator II v1.0 (1983)(subLOGIC)[cr Midwest Pirates Guild - 1200 Club].dsk" offset="0" sha1="cb451baf2e298197e413c2808c647263" size="143360" /></dataarea></part></software>
+<software name="FlightSicrM">
+<description>Flight Simulator II v1.0 </description>
+<year>1983</year>
+<publisher>subLOGIC</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="95986bea" name="Flight Simulator II v1.0 (1983)(subLOGIC)[cr Midwest Pirates Guild - 1200 Club][a].dsk" offset="0" sha1="f720c66b55f84f0b926db54ee05f96d8" size="143360" /></dataarea></part></software>
+<software name="FooblitzcrD">
+<description>Fooblitzky </description>
+<year>1985</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="70771477" name="Fooblitzky (1985)(Infocom)[cr Digital Gang].dsk" offset="0" sha1="3dc3553dc6ecfac9304466ee8a5bf272" size="143360" /></dataarea></part></software>
+<software name="ForceSev">
+<description>Force Seven </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6c69295b" name="Force Seven (1987)(Datasoft).dsk" offset="0" sha1="b0051b17d9862146e89290c5fba5db27" size="143360" /></dataarea></part></software>
+<software name="ForceSevcrC">
+<description>Force Seven </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="b89240ec" name="Force Seven (1987)(Datasoft)[cr Coast to Coast][o].dsk" offset="0" sha1="5de0f713944d62035dc943ebebd0b2b5" size="143363" /></dataarea></part></software>
+<software name="ForceSevcrC">
+<description>Force Seven </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143616">
+<rom crc="2721f474" name="Force Seven (1987)(Datasoft)[cr Coast to Coast][o][a].dsk" offset="0" sha1="8171435bfa6ed3602145b607f0503876" size="143616" /></dataarea></part></software>
+<software name="G.I.Joe">
+<description>G.I. Joe </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ee151352" name="G.I. Joe (1985)(Epyx)(Side A).dsk" offset="0" sha1="f6c1fe3501e199c3078d81e946de9d8b" size="143360" /></dataarea></part></software>
+<software name="G.I.JoecrB">
+<description>G.I. Joe </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d9e329ae" name="G.I. Joe (1985)(Epyx)(Side A)[cr Blade][b].dsk" offset="0" sha1="445666a8518beba6b32bb71e170e940b" size="143360" /></dataarea></part></software>
+<software name="G.I.JoecrF">
+<description>G.I. Joe </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="927b30a7" name="G.I. Joe (1985)(Epyx)(Side A)[cr Five Star][b].dsk" offset="0" sha1="1e7639ca14554dbbf70830d45dc17185" size="143360" /></dataarea></part></software>
+<software name="G.I.JoecrF">
+<description>G.I. Joe </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="10af5953" name="G.I. Joe (1985)(Epyx)(Side B)[cr Five Star][b].dsk" offset="0" sha1="679c8ea8352a15ae8dd675baf3d1f31c" size="143360" /></dataarea></part></software>
+<software name="GalacticRDO">
+<description>Galactic Adventures </description>
+<year>1982</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fb0e136b" name="Galactic Adventures (1982)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="4d6076b3536ca229ab6e8b42c98d43d6" size="143360" /></dataarea></part></software>
+<software name="GalacticRDO">
+<description>Galactic Adventures </description>
+<year>1982</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e2ebcf0" name="Galactic Adventures (1982)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="feda40e60be4cf684011181ce5d2d353" size="143360" /></dataarea></part></software>
+<software name="GalacticcrM">
+<description>Galactic Attack </description>
+<year>1980</year>
+<publisher>Siro-tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e4a23c58" name="Galactic Attack (1980)(Siro-tech)[cr Mr. Clean][PASCAL].dsk" offset="0" sha1="ad83426e705ed6b2105b76a5e458fd3a" size="143360" /></dataarea></part></software>
+<software name="Galacticcr">
+<description>Galactic Attack </description>
+<year>1980</year>
+<publisher>Siro-tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1eba7b98" name="Galactic Attack (1980)(Siro-tech)[cr][PASCAL].dsk" offset="0" sha1="b6fab2fd5628d194ec81ad841db99f59" size="143360" /></dataarea></part></software>
+<software name="GalacticRDO">
+<description>Galactic Gladiator </description>
+<year>19xx</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b1d69781" name="Galactic Gladiator (19xx)(SSI)[RDOS].dsk" offset="0" sha1="fdbab922f908bf5f61c6d6c450d4b31b" size="143360" /></dataarea></part></software>
+<software name="Games-SucrB">
+<description>Games - Summer Edition, The </description>
+<year>1984</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="455977a4" name="Games - Summer Edition, The (1984)(Epyx)(Disk 1 of 2 Side A)[cr Blade].dsk" offset="0" sha1="e79a4dac29856b07ebb48495217bf062" size="143360" /></dataarea></part></software>
+<software name="Games-SucrB">
+<description>Games - Summer Edition, The </description>
+<year>1984</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="06bc6e83" name="Games - Summer Edition, The (1984)(Epyx)(Disk 1 of 2 Side B)[cr Blade].dsk" offset="0" sha1="0155f18596b124c90a6ec06848846cd0" size="143360" /></dataarea></part></software>
+<software name="Games-SucrB">
+<description>Games - Summer Edition, The </description>
+<year>1984</year>
+<publisher>Disk 2 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c357f7d3" name="Games - Summer Edition, The (1984)(Epyx)(Disk 2 of 2 Side A)[cr Blade].dsk" offset="0" sha1="0f574dce0abcc36f28bc6d3dacd7cadf" size="143360" /></dataarea></part></software>
+<software name="Games-SucrB">
+<description>Games - Summer Edition, The </description>
+<year>1984</year>
+<publisher>Disk 2 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d6305002" name="Games - Summer Edition, The (1984)(Epyx)(Disk 2 of 2 Side B)[cr Blade].dsk" offset="0" sha1="2e1db98cb3f381906e67267b110404e8" size="143360" /></dataarea></part></software>
+<software name="GamesWin">
+<description>Games Winter Edition, The </description>
+<year>1988</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="298d8265" name="Games Winter Edition, The (1988)(Epyx)(Disk 1 of 3 Side A).dsk" offset="0" sha1="43a1a1e9bcf9c582f69856f067e0c19b" size="143360" /></dataarea></part></software>
+<software name="GamesWin">
+<description>Games Winter Edition, The </description>
+<year>1988</year>
+<publisher>Disk 1 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c69ef96a" name="Games Winter Edition, The (1988)(Epyx)(Disk 1 of 3 Side B).dsk" offset="0" sha1="029207ded23d6714beb680915cb2ce6c" size="143360" /></dataarea></part></software>
+<software name="GamesWin">
+<description>Games Winter Edition, The </description>
+<year>1988</year>
+<publisher>Disk 2 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5b43f514" name="Games Winter Edition, The (1988)(Epyx)(Disk 2 of 3 Side A).dsk" offset="0" sha1="026b2a53ae8c211a6a76bd0a7962393c" size="143360" /></dataarea></part></software>
+<software name="GamesWin">
+<description>Games Winter Edition, The </description>
+<year>1988</year>
+<publisher>Disk 2 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4b10934f" name="Games Winter Edition, The (1988)(Epyx)(Disk 2 of 3 Side B).dsk" offset="0" sha1="5194600538ea8c5efcd5701fc485338a" size="143360" /></dataarea></part></software>
+<software name="GamesWin">
+<description>Games Winter Edition, The </description>
+<year>1988</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0bea31db" name="Games Winter Edition, The (1988)(Epyx)(Disk 3 of 3).dsk" offset="0" sha1="21431b6ab06481af9c10aceff456f3c8" size="143360" /></dataarea></part></software>
+<software name="GatocrR">
+<description>Gato </description>
+<year>1985</year>
+<publisher>Spectrum Holobyte</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="11209c22" name="Gato (1985)(Spectrum Holobyte)[cr Racketeers - Wareforce][PASCAL].dsk" offset="0" sha1="83214916baa04770b184d85329e85156" size="143360" /></dataarea></part></software>
+<software name="GatoPAS">
+<description>Gato </description>
+<year>1985</year>
+<publisher>Spectrum Holobyte</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8898580f" name="Gato (1985)(Spectrum Holobyte)[PASCAL].dsk" offset="0" sha1="6340ebe25621f05f957f26942118b894" size="143360" /></dataarea></part></software>
+<software name="Gauntlet">
+<description>Gauntlet </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="218e795b" name="Gauntlet (1986)(Atari - Mindscape)(Side A).dsk" offset="0" sha1="5d821e28bf233995cb00c307b2cc5adb" size="143360" /></dataarea></part></software>
+<software name="Gauntlet">
+<description>Gauntlet </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="173848c7" name="Gauntlet (1986)(Atari - Mindscape)(Side B).dsk" offset="0" sha1="99af0c7b3f43eaab11cc45d25f892b15" size="143360" /></dataarea></part></software>
+<software name="GeopolitRDO">
+<description>Geopolitique 1990 </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5eafb3c1" name="Geopolitique 1990 (1983)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="82bcaec4d360b38d7669804b54fd47b7" size="143360" /></dataarea></part></software>
+<software name="GeopolitRDO">
+<description>Geopolitique 1990 </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc678edf" name="Geopolitique 1990 (1983)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="0f7a71e27c24428a65c2fc2e3bd45e75" size="143360" /></dataarea></part></software>
+<software name="GettysbuRDO">
+<description>Gettysburg - The Turning Poing </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="53c41799" name="Gettysburg - The Turning Poing (1986)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="28ee7c3ba5c347a8c6aef53d5a4516b9" size="143360" /></dataarea></part></software>
+<software name="GettysbuRDO">
+<description>Gettysburg - The Turning Poing </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8154c7ba" name="Gettysburg - The Turning Poing (1986)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="1d76c3e710636e64b9235b5239f11f44" size="143360" /></dataarea></part></software>
+<software name="Ghostbus">
+<description>Ghostbusters </description>
+<year>1984</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e676fa4b" name="Ghostbusters (1984)(Activision).dsk" offset="0" sha1="4b83d25641d4703cf1f48d61fd866896" size="143360" /></dataarea></part></software>
+<software name="GhostbushRa">
+<description>Ghostbusters </description>
+<year>1984</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b92c6677" name="Ghostbusters (1984)(Activision)[h Rato Tech].dsk" offset="0" sha1="35af00722d549efc1fb1ea410b47ad22" size="143360" /></dataarea></part></software>
+<software name="GoldfingcrF">
+<description>Goldfinger </description>
+<year>1986</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9518d520" name="Goldfinger (1986)(Mindscape)[cr First Class][PASCAL].dsk" offset="0" sha1="3aa9c80cf374469dcc64ddf80716d867" size="143360" /></dataarea></part></software>
+<software name="GooniesTcrC">
+<description>Goonies, The </description>
+<year>19xx</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="12172b55" name="Goonies, The (19xx)(Datasoft)[cr Club X - First Class].dsk" offset="0" sha1="fde257622cf6cc2655df37bb14090e93" size="143360" /></dataarea></part></software>
+<software name="GreatAmecrD">
+<description>Great American Cross-Country Road Race, The </description>
+<year>1985</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f07a2ba5" name="Great American Cross-Country Road Race, The (1985)(Activision)[cr Digital Gang].dsk" offset="0" sha1="34fcca4ff002f757129c2d051d27c13e" size="143360" /></dataarea></part></software>
+<software name="GremlinscrW">
+<description>Gremlins </description>
+<year>1984</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a9df57f9" name="Gremlins (1984)(Atari)[cr West Coast Pirates' Exchange].dsk" offset="0" sha1="bbd6e1aa01660045704b77f9eb49a753" size="143360" /></dataarea></part></software>
+<software name="GremlinscrW">
+<description>Gremlins </description>
+<year>1984</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="499bc975" name="Gremlins (1984)(Atari)[cr West Coast Pirates' Exchange][a].dsk" offset="0" sha1="8e628c8021a1dae6dc1ee4de1c608e6b" size="143360" /></dataarea></part></software>
+<software name="GremlinscrW">
+<description>Gremlins </description>
+<year>1984</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="c19ffcf0" name="Gremlins (1984)(Atari)[cr West Coast Pirates' Exchange][o].dsk" offset="0" sha1="4d7ceba3f7cfdb0cc68a702d8bfcc1cd" size="143363" /></dataarea></part></software>
+<software name="GuadalcaRDO">
+<description>Guadalcanal Campaign v1.1 </description>
+<year>198x</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc2742ae" name="Guadalcanal Campaign v1.1 (198x)(SSI)[RDOS].dsk" offset="0" sha1="4a3cf3ad2adadc0721a2652a6faa8d63" size="143360" /></dataarea></part></software>
+<software name="Gumball">
+<description>Gumball </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="719375ca" name="Gumball (1983)(Broderbund).dsk" offset="0" sha1="6e5a39dd76ea0c1e62ac94228b93541b" size="143360" /></dataarea></part></software>
+<software name="Gumballa">
+<description>Gumball </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="daf671aa" name="Gumball (1983)(Broderbund)[a].dsk" offset="0" sha1="2c19307ee5b7acc914c1c9f14228ae39" size="143360" /></dataarea></part></software>
+<software name="Gumballo">
+<description>Gumball </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="528188bd" name="Gumball (1983)(Broderbund)[o].dsk" offset="0" sha1="6dfa2a676919ec6fe560945097d30d7c" size="143488" /></dataarea></part></software>
+<software name="Gunfightcr1">
+<description>Gunfight </description>
+<year>19xx</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="50d4f377" name="Gunfight (19xx)(SSI)[cr 1200 Club][RDOS].dsk" offset="0" sha1="f9a1440780f1dd1b954274b245a733c0" size="143360" /></dataarea></part></software>
+<software name="GyroscopcrK">
+<description>Gyroscope </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7b2eabd7" name="Gyroscope (1986)(Melbourne House Game)(Side A)[cr King Krak Klub].dsk" offset="0" sha1="985dd62f85a04dc0da70ff907ed52aeb" size="143360" /></dataarea></part></software>
+<software name="GyroscopcrK">
+<description>Gyroscope </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="859af749" name="Gyroscope (1986)(Melbourne House Game)(Side B)[cr King Krak Klub].dsk" offset="0" sha1="d35d549660387ed88c6c8551e88d0912" size="143360" /></dataarea></part></software>
+<software name="HalleyPrcrL">
+<description>Halley Project, The </description>
+<year>1985</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1d96f887" name="Halley Project, The (1985)(Mindscape)[cr L.S.D.].dsk" offset="0" sha1="fe11e53e61bebedde6ca94e6ea1738b3" size="143360" /></dataarea></part></software>
+<software name="Hallowe'">
+<description>Hallowe'en </description>
+<year>1983</year>
+<publisher>Micro-Sparc</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="615cf563" name="Hallowe'en (1983)(Micro-Sparc).dsk" offset="0" sha1="107b900d5538d1f3f73553ca3f331309" size="143360" /></dataarea></part></software>
+<software name="Hawaii">
+<description>Hawaii </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c9dbf8a2" name="Hawaii (1986)(Excalibur)(fr)(Side A).dsk" offset="0" sha1="b7c687c7aea2f16e8a2c91313a89deb3" size="143360" /></dataarea></part></software>
+<software name="Hawaii">
+<description>Hawaii </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="daf42144" name="Hawaii (1986)(Excalibur)(fr)(Side B).dsk" offset="0" sha1="3ffe76c731748105b41aed17f70b2564" size="143360" /></dataarea></part></software>
+<software name="HeavyBar">
+<description>Heavy Barrell </description>
+<year>1989</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22218a55" name="Heavy Barrell (1989)(Data East)(Side A).dsk" offset="0" sha1="06b20005bffbe3b4bfeced42ecaf292a" size="143360" /></dataarea></part></software>
+<software name="HeistThe">
+<description>Heist, The </description>
+<year>1983</year>
+<publisher>Microfun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8f35643f" name="Heist, The (1983)(Microfun).dsk" offset="0" sha1="835858ace0a0c8ff1579a28c2f8a2451" size="143360" /></dataarea></part></software>
+<software name="HeistThecrB">
+<description>Heist, The </description>
+<year>1983</year>
+<publisher>Microfun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7d437863" name="Heist, The (1983)(Microfun)[cr Blade].dsk" offset="0" sha1="19c48b8208f793ef71620ff6f68f6cbe" size="143360" /></dataarea></part></software>
+<software name="HeistTheo">
+<description>Heist, The </description>
+<year>1983</year>
+<publisher>Microfun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="513a40de" name="Heist, The (1983)(Microfun)[o].dsk" offset="0" sha1="30a063bf946e858de87aefe7bdf1429c" size="143488" /></dataarea></part></software>
+<software name="Hera">
+<description>Hera </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7021ca66" name="Hera (1987)(Hendrix, Jeff)(SW)(Side B).dsk" offset="0" sha1="054c33040aa364cc3e8088e6ddb2708a" size="143360" /></dataarea></part></software>
+<software name="HesgamescrC">
+<description>Hesgames </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1baebce5" name="Hesgames (1984)(Hesware)(Disk 1 of 2)[cr Club].dsk" offset="0" sha1="aea02c5c99f0396b7f37c4e230234b0a" size="143360" /></dataarea></part></software>
+<software name="HesgamescrC">
+<description>Hesgames </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="37b598cb" name="Hesgames (1984)(Hesware)(Disk 2 of 2)[cr Club].dsk" offset="0" sha1="9b0fab9dde9f577532599aa87519a16b" size="143360" /></dataarea></part></software>
+<software name="Hi-ResAdcrB">
+<description>Hi-Res Adventure 0 - Mission Asteroid </description>
+<year>1980</year>
+<publisher>On-Line Systems</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3904aa9e" name="Hi-Res Adventure 0 - Mission Asteroid (1980)(On-Line Systems)[cr Black Bag].dsk" offset="0" sha1="226b961af07993f9107d627333073949" size="143360" /></dataarea></part></software>
+<software name="HighStakcrF">
+<description>High Stakes </description>
+<year>1986</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="65ae5a79" name="High Stakes (1986)(Mindscape)[cr First Class][PASCAL].dsk" offset="0" sha1="9810d147ef5163b480a87ef1a743dc3b" size="143360" /></dataarea></part></software>
+<software name="Hitchhik">
+<description>Hitchhiker's Guide to the Galaxy, The </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f9bc74ec" name="Hitchhiker's Guide to the Galaxy, The (1984)(Infocom).dsk" offset="0" sha1="3aad9e648dfbc799158f50eb0b948b00" size="143360" /></dataarea></part></software>
+<software name="Hitchhika">
+<description>Hitchhiker's Guide to the Galaxy, The </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc05d339" name="Hitchhiker's Guide to the Galaxy, The (1984)(Infocom)[a].dsk" offset="0" sha1="a4ab6c687a8fbb8ccc2b7ef2027e6342" size="143360" /></dataarea></part></software>
+<software name="HitchhikcrB">
+<description>Hitchhiker's Guide to the Galaxy, The </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e1e72bb8" name="Hitchhiker's Guide to the Galaxy, The (1984)(Infocom)[cr Blade].dsk" offset="0" sha1="e1af8e7db5e1216b61d4c31429760b0b" size="143360" /></dataarea></part></software>
+<software name="HobbitThcrR">
+<description>Hobbit, The </description>
+<year>19xx</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="483f8d6e" name="Hobbit, The (19xx)(DPC Elite)(Side A)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="97441840b3c23d08fc6c314fa1fbd9f0" size="143360" /></dataarea></part></software>
+<software name="HobbitThcrR">
+<description>Hobbit, The </description>
+<year>19xx</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="29dea4fc" name="Hobbit, The (19xx)(DPC Elite)(Side B)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="7dbf55d2dd1dfe71597e373e1de42893" size="143360" /></dataarea></part></software>
+<software name="Hollywoo">
+<description>Hollywood Hijinx </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="84f1a097" name="Hollywood Hijinx (1986)(Infocom).dsk" offset="0" sha1="1698e668524a3c04576462d4f4482403" size="143360" /></dataarea></part></software>
+<software name="Hollywooa">
+<description>Hollywood Hijinx </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ade09cb4" name="Hollywood Hijinx (1986)(Infocom)[a].dsk" offset="0" sha1="52aa5f25710f18629a0457a3380caf28" size="143360" /></dataarea></part></software>
+<software name="HorseRaca">
+<description>Horse Racing Classic </description>
+<year>1982</year>
+<publisher>Tazumi</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0d01ff52" name="Horse Racing Classic (1982)(Tazumi)[a][PASCAL].dsk" offset="0" sha1="9802e05897e98717d7f32ed8ebe358bc" size="143360" /></dataarea></part></software>
+<software name="HorseRacPAS">
+<description>Horse Racing Classic </description>
+<year>1982</year>
+<publisher>Tazumi</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8faa7fef" name="Horse Racing Classic (1982)(Tazumi)[PASCAL].dsk" offset="0" sha1="2e03d059b25058a583ac461aa9f2e21f" size="143360" /></dataarea></part></software>
+<software name="HowsAboucrT">
+<description>Hows About a Nice Game of Chess </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7c7dab81" name="Hows About a Nice Game of Chess (19xx)(-)[cr Tom E. Hawk].dsk" offset="0" sha1="1a9d7bae7574475cbdf80917fbd692be" size="143360" /></dataarea></part></software>
+<software name="I-DamiancrB">
+<description>I-Damiano </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="16cd4d0b" name="I-Damiano (1985)(Bantam)(Side A)[cr Big Birder].dsk" offset="0" sha1="dd472a001325eb2bd3b4aa9ce89bea7d" size="143360" /></dataarea></part></software>
+<software name="I-DamiancrB">
+<description>I-Damiano </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="276c02b8" name="I-Damiano (1985)(Bantam)(Side B)[cr Big Birder].dsk" offset="0" sha1="39e5755668e686cb301038569a282e8d" size="143360" /></dataarea></part></software>
+<software name="ImperiumRDO">
+<description>Imperium Galactum </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e2a7fc57" name="Imperium Galactum (1984)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="d919caae16418ca78726e5deb9ccef82" size="143360" /></dataarea></part></software>
+<software name="ImperiumRDO">
+<description>Imperium Galactum </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4e65222b" name="Imperium Galactum (1984)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="014f2328390a4c26f661c4a1aae84a7a" size="143360" /></dataarea></part></software>
+<software name="ImpossibcrS">
+<description>Impossible Mission </description>
+<year>1982</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7f20b34e" name="Impossible Mission (1982)(Epyx)[cr Shaolin Disciples].dsk" offset="0" sha1="25f2982516f23646f704c624ee0d092d" size="143360" /></dataarea></part></software>
+<software name="ImpossibcrU">
+<description>Impossible Mission II </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="69052055" name="Impossible Mission II (1988)(Epyx)(Side A)[cr USAlliance].dsk" offset="0" sha1="1a0d9cd11772041cacc47470fb35793d" size="143360" /></dataarea></part></software>
+<software name="ImpossibcrU">
+<description>Impossible Mission II </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7968cf85" name="Impossible Mission II (1988)(Epyx)(Side B)[cr USAlliance].dsk" offset="0" sha1="513f909232f4aaa3ee0d19262011586e" size="143360" /></dataarea></part></software>
+<software name="IndianaJcrF">
+<description>Indiana Jones in Revenge of the Ancients </description>
+<year>1987</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ccf26bbc" name="Indiana Jones in Revenge of the Ancients (1987)(Mindscape)[cr First Class][PASCAL].dsk" offset="0" sha1="66498121ad4591837f561ca2b77328ab" size="143360" /></dataarea></part></software>
+<software name="IndianaJPAS">
+<description>Indiana Jones in Revenge of the Ancients </description>
+<year>1987</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e92a413f" name="Indiana Jones in Revenge of the Ancients (1987)(Mindscape)[PASCAL].dsk" offset="0" sha1="1c9505c9164615bf4fe73669559117ca" size="143360" /></dataarea></part></software>
+<software name="Infidel">
+<description>Infidel </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="720fef81" name="Infidel (1983)(Infocom).dsk" offset="0" sha1="a07a159e340d0622409eb93d3dee48cd" size="143360" /></dataarea></part></software>
+<software name="Infidela">
+<description>Infidel </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="33f802f3" name="Infidel (1983)(Infocom)[a].dsk" offset="0" sha1="5eae8a132dd590560e853cef9a3f9331" size="143360" /></dataarea></part></software>
+<software name="InfiltracrB">
+<description>Infiltrator </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ba4aa79b" name="Infiltrator (1987)(Mindscape)(Side A)[cr Blade].dsk" offset="0" sha1="7d144888a36a9ecbd6fd8174a51ae083" size="143360" /></dataarea></part></software>
+<software name="InfiltracrF">
+<description>Infiltrator </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f9f9e9ef" name="Infiltrator (1987)(Mindscape)(Side A)[cr First Class].dsk" offset="0" sha1="9bbc3613220c183b049f2bb5f59e5a9f" size="143360" /></dataarea></part></software>
+<software name="InfiltracrB">
+<description>Infiltrator </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8110da51" name="Infiltrator (1987)(Mindscape)(Side B)[cr Blade].dsk" offset="0" sha1="f6133aca688a2e07753cf0b5bedbf02b" size="143360" /></dataarea></part></software>
+<software name="InfiltracrF">
+<description>Infiltrator </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="46cc2c3a" name="Infiltrator (1987)(Mindscape)(Side B)[cr First Class].dsk" offset="0" sha1="ca02f60e592e118aff8400653079773b" size="143360" /></dataarea></part></software>
+<software name="Infiltra">
+<description>Infiltrator Part II - The Next Day </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cfca8ab1" name="Infiltrator Part II - The Next Day (1988)(Mindscape)(Side A).dsk" offset="0" sha1="f31a5c05c24f54e96b7522a3e64b9bc7" size="143360" /></dataarea></part></software>
+<software name="Infiltra">
+<description>Infiltrator Part II - The Next Day </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="54044fee" name="Infiltrator Part II - The Next Day (1988)(Mindscape)(Side B).dsk" offset="0" sha1="f70958bb69f0d236a90c80dc8b6845d0" size="143360" /></dataarea></part></software>
+<software name="InjuredEcrA">
+<description>Injured Engine </description>
+<year>1984</year>
+<publisher>Imagic</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b334713a" name="Injured Engine (1984)(Imagic)[cr Atlantic Pirates Guild].dsk" offset="0" sha1="d63a6f654cb7a7426fcfdc93d0cf2e4d" size="143360" /></dataarea></part></software>
+<software name="IntriguecrB">
+<description>Intrigue </description>
+<year>19xx</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="daf9858b" name="Intrigue (19xx)(-)(Disk 1 of 2)[cr Bunnymen][b].dsk" offset="0" sha1="69545f9e9d3d0648d870c26a4caff56c" size="143360" /></dataarea></part></software>
+<software name="IntriguecrB">
+<description>Intrigue </description>
+<year>19xx</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1ccb6a43" name="Intrigue (19xx)(-)(Disk 2 of 2)[cr Bunnymen][b].dsk" offset="0" sha1="2f8a68ca0263d254ae2f71890d102407" size="143360" /></dataarea></part></software>
+<software name="JamesBoncrM">
+<description>James Bond 007 - A View to a Kill </description>
+<year>1985</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2b8c529d" name="James Bond 007 - A View to a Kill (1985)(Mindscape)[cr Mr. Slick][PASCAL].dsk" offset="0" sha1="d16633fa1142d34c95cf0ee0761ecac2" size="143360" /></dataarea></part></software>
+<software name="JigSawcrB">
+<description>Jig Saw </description>
+<year>1984</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="27e9d8b9" name="Jig Saw (1984)(-)[cr Black Bag - Club].dsk" offset="0" sha1="a0c0fceba5f6b51176e4b57c0fcaa4e2" size="143360" /></dataarea></part></software>
+<software name="JoeTheiscrF">
+<description>Joe Theismann's Pro Football </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eb6b890a" name="Joe Theismann's Pro Football (1985)(Avant-Garde)(Side A)[cr First Class].dsk" offset="0" sha1="94eda650fd17f27b6e331adbe9043056" size="143360" /></dataarea></part></software>
+<software name="JoeTheiscrF">
+<description>Joe Theismann's Pro Football </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f78c7e35" name="Joe Theismann's Pro Football (1985)(Avant-Garde)(Side B)[cr First Class].dsk" offset="0" sha1="13904d5c88286871579c37d6414bb700" size="143360" /></dataarea></part></software>
+<software name="JourneyicrF">
+<description>Journey into Darkness </description>
+<year>1986</year>
+<publisher>Earthware</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="94c895ac" name="Journey into Darkness (1986)(Earthware)[cr First Class].dsk" offset="0" sha1="db07d61b737b846a150af8e7be3a0537" size="143360" /></dataarea></part></software>
+<software name="JumpmancrW">
+<description>Jumpman </description>
+<year>1983</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cb8a8d32" name="Jumpman (1983)(Epyx)(Side A)[cr Woz].dsk" offset="0" sha1="ef76a8f6126c6f4b589efd3d9d14b719" size="143360" /></dataarea></part></software>
+<software name="JumpmancrW">
+<description>Jumpman </description>
+<year>1983</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a7f586b9" name="Jumpman (1983)(Epyx)(Side B)[cr Woz].dsk" offset="0" sha1="3fcfafd826efdd5fb7efd4549a0befbe" size="143360" /></dataarea></part></software>
+<software name="KabulSpycrK">
+<description>Kabul Spy </description>
+<year>1982</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="916517e9" name="Kabul Spy (1982)(Sirius Software)(Side A)[cr Kracware].dsk" offset="0" sha1="989a7edb5e22e8a17f2d39efc5c91a3c" size="143360" /></dataarea></part></software>
+<software name="KabulSpycrK">
+<description>Kabul Spy </description>
+<year>1982</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="24b05f6c" name="Kabul Spy (1982)(Sirius Software)(Side B)[cr Kracware].dsk" offset="0" sha1="54ee8b1b308097864b1ebbbd0c6d8a29" size="143360" /></dataarea></part></software>
+<software name="KampfgruRDO">
+<description>Kampfgruppe </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c6c3e5ab" name="Kampfgruppe (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="87eade9c90fe9b5d2a802d4138e5cbf9" size="143360" /></dataarea></part></software>
+<software name="Kampfgrua">
+<description>Kampfgruppe </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8fd97096" name="Kampfgruppe (1985)(SSI)(Side B)[a].dsk" offset="0" sha1="5335312d32690a8f74113271e8724ca3" size="143360" /></dataarea></part></software>
+<software name="KampfgruRDO">
+<description>Kampfgruppe </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8e22bb90" name="Kampfgruppe (1985)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="6a5f5911f5d2c5b0a694dc361752379d" size="143360" /></dataarea></part></software>
+<software name="Karateka">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5a5a298b" name="Karateka (1984)(Broderbund).dsk" offset="0" sha1="c4e9ba49171ba4724ca4fac2d96f7791" size="143360" /></dataarea></part></software>
+<software name="Karatekaa2">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a841d09b" name="Karateka (1984)(Broderbund)[a2].dsk" offset="0" sha1="fdbe4522ea497e98f3526a1d10de5129" size="143360" /></dataarea></part></software>
+<software name="Karatekaa3">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9cc59d35" name="Karateka (1984)(Broderbund)[a3].dsk" offset="0" sha1="bd8f715229edb3e4a877b4ed885ce379" size="143360" /></dataarea></part></software>
+<software name="Karatekaa">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8ab18285" name="Karateka (1984)(Broderbund)[a].dsk" offset="0" sha1="1d78ba17c8f0d4265ae28945d7ace97d" size="143360" /></dataarea></part></software>
+<software name="KaratekacrA">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="342a8587" name="Karateka (1984)(Broderbund)[cr Association of Broadcasting Crackers].dsk" offset="0" sha1="14ea0a54affb2abf150f079d68d91943" size="143360" /></dataarea></part></software>
+<software name="KaratekacrR">
+<description>Karateka </description>
+<year>1984</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="81caf379" name="Karateka (1984)(Broderbund)[cr Racketeers].dsk" offset="0" sha1="dec892a944d6592044b8d6c81d97006d" size="143360" /></dataarea></part></software>
+<software name="KenustoncrM">
+<description>Kenuston's Professional Blackjack v1.10 </description>
+<year>1982</year>
+<publisher>Intelligent Statement</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0af14700" name="Kenuston's Professional Blackjack v1.10 (1982)(Intelligent Statement)[cr Mr. Krac-Man].dsk" offset="0" sha1="136b2bea4dab9fc68bfda0c2ec828bb0" size="143360" /></dataarea></part></software>
+<software name="KilledUncrF">
+<description>Killed Until Dead </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b3fd0992" name="Killed Until Dead (1986)(Accolade)(Side A)[cr First Class].dsk" offset="0" sha1="f2f126a1402b569dbaf18af4a02d8f95" size="143360" /></dataarea></part></software>
+<software name="KilledUncrF">
+<description>Killed Until Dead </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bf06007c" name="Killed Until Dead (1986)(Accolade)(Side B)[cr First Class].dsk" offset="0" sha1="9babee1af2154c5dd6eff40565674f2e" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 1 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="58558fb2" name="King Quest IV (1988)(Sierra)(Disk 1 of 8 Side A)[b].dsk" offset="0" sha1="6db1237a6a995bc79b76c2c58a2087d6" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 1 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4ee81c54" name="King Quest IV (1988)(Sierra)(Disk 1 of 8 Side B)[b].dsk" offset="0" sha1="fcf22aa9c7a36ac680456480c8e345c1" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 2 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="da70005c" name="King Quest IV (1988)(Sierra)(Disk 2 of 8 Side A)[b].dsk" offset="0" sha1="1b9eecd8a606709e998bbad549e084b4" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 2 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f64c07fe" name="King Quest IV (1988)(Sierra)(Disk 2 of 8 Side B)[b].dsk" offset="0" sha1="183a12450ebe95b248b17155e16a25e4" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 3 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e952fb24" name="King Quest IV (1988)(Sierra)(Disk 3 of 8 Side A)[b].dsk" offset="0" sha1="1fba2f189ee0f52b47a8a8b78fc9775c" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 3 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="af24fb31" name="King Quest IV (1988)(Sierra)(Disk 3 of 8 Side B)[b].dsk" offset="0" sha1="f2a7e9c5921115b87b79d85a19da85af" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 4 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f9d4fae5" name="King Quest IV (1988)(Sierra)(Disk 4 of 8 Side A)[b].dsk" offset="0" sha1="544645fe7f658bde7f5b7b7e5ff1ce10" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 4 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aa6490f2" name="King Quest IV (1988)(Sierra)(Disk 4 of 8 Side B)[b].dsk" offset="0" sha1="5062b27681c7b9aa1918681dec8cd13c" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 5 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7bcdb0b0" name="King Quest IV (1988)(Sierra)(Disk 5 of 8 Side A)[b].dsk" offset="0" sha1="850b92ff79563b31a4bbe0b000bca7a2" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 5 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="43b46956" name="King Quest IV (1988)(Sierra)(Disk 5 of 8 Side B)[b].dsk" offset="0" sha1="8578bdfa8a2d266abe819e9086b5bc21" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 6 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="33522c9f" name="King Quest IV (1988)(Sierra)(Disk 6 of 8 Side A)[b].dsk" offset="0" sha1="669826ba65a75bd36b16f0b3f29a4d00" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 6 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3b514433" name="King Quest IV (1988)(Sierra)(Disk 6 of 8 Side B)[b].dsk" offset="0" sha1="588ff7cdf5baabb829c052e1ec119e91" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 7 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d36dcec1" name="King Quest IV (1988)(Sierra)(Disk 7 of 8 Side A)[b].dsk" offset="0" sha1="ada0df82ceddc2b3b8a04d80bd66d7a4" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 7 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4f325afa" name="King Quest IV (1988)(Sierra)(Disk 7 of 8 Side B)[b].dsk" offset="0" sha1="9238bf878599d1d304ca40f467450ed8" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 8 of 8 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5dc8d034" name="King Quest IV (1988)(Sierra)(Disk 8 of 8 Side A)[b].dsk" offset="0" sha1="fbf9edd6b6ca8200f321a6395dcaeea3" size="143360" /></dataarea></part></software>
+<software name="KingQuesb">
+<description>King Quest IV </description>
+<year>1988</year>
+<publisher>Disk 8 of 8 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b62f503a" name="King Quest IV (1988)(Sierra)(Disk 8 of 8 Side B)[b].dsk" offset="0" sha1="8c33cf6285381f92b608ce933aadfed5" size="143360" /></dataarea></part></software>
+<software name="King'sBob">
+<description>King's Bounty </description>
+<year>1990</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c80aa667" name="King's Bounty (1990)(New World Computing)(Side A)[b].dsk" offset="0" sha1="c839a306af824a42d285b9332be8e389" size="143360" /></dataarea></part></software>
+<software name="King'sBo">
+<description>King's Bounty </description>
+<year>1990</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d72be240" name="King's Bounty (1990)(New World Computing)(Side B).dsk" offset="0" sha1="2eeba455fd3e9d3eabead1a1a6a2e4d7" size="143360" /></dataarea></part></software>
+<software name="King'sBoa">
+<description>King's Bounty </description>
+<year>1990</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7dfbabc0" name="King's Bounty (1990)(New World Computing)(Side B)[a].dsk" offset="0" sha1="3973cb08cd29a6a6af1b5643ec26c664" size="143360" /></dataarea></part></software>
+<software name="KnightsocrM">
+<description>Knights of the Desert </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3b5d18e4" name="Knights of the Desert (1983)(SSI)[cr Mr. Krac-Man][RDOS].dsk" offset="0" sha1="276c136883902bb75a64bfdf31de95ba" size="143360" /></dataarea></part></software>
+<software name="Knockout">
+<description>Knockout </description>
+<year>1994</year>
+<publisher>FW</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143390">
+<rom crc="f7768030" name="Knockout (1994)(American Research)(FW).dsk" offset="0" sha1="239be4e16c750a52358af114905359df" size="143390" /></dataarea></part></software>
+<software name="KoronisRcrF">
+<description>Koronis Rift </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="28f8d93a" name="Koronis Rift (1985)(Lucasfilm Games)[cr First Class][o].dsk" offset="0" sha1="a210c82d5591981f87ccf97a1535f04a" size="143363" /></dataarea></part></software>
+<software name="KoronisRcrL">
+<description>Koronis Rift </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bbc550ab" name="Koronis Rift (1985)(Lucasfilm Games)[cr Lot - The Mad Mechanic].dsk" offset="0" sha1="cd33930d0bc226f952f963568aeb027e" size="143360" /></dataarea></part></software>
+<software name="KungFuMacrT">
+<description>Kung Fu Master </description>
+<year>1985</year>
+<publisher>Dataeast</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="30502e45" name="Kung Fu Master (1985)(Dataeast)[cr Thing].dsk" offset="0" sha1="f228552421a8b77929bea75844025e45" size="143360" /></dataarea></part></software>
+<software name="LastGladcrF">
+<description>Last Gladiator, The </description>
+<year>1983</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0fbeccae" name="Last Gladiator, The (1983)(Electronic Arts)[cr Freeze - L.S.D.].dsk" offset="0" sha1="b2acbc814e5d1be941aaf027f00c4c2c" size="143360" /></dataarea></part></software>
+<software name="LastNinjcrC">
+<description>Last Ninja </description>
+<year>19xx</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8100eec3" name="Last Ninja (19xx)(Activision)(Disk 1 of 3)[cr Coast to Coast].dsk" offset="0" sha1="7ec8b8a40889b97638dc27852707c682" size="143360" /></dataarea></part></software>
+<software name="LastNinjcrC">
+<description>Last Ninja </description>
+<year>19xx</year>
+<publisher>Disk 2 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2707d373" name="Last Ninja (19xx)(Activision)(Disk 2 of 3)[cr Coast to Coast].dsk" offset="0" sha1="eba8445fc1a95152563514fa73d37d40" size="143360" /></dataarea></part></software>
+<software name="LastNinjcrC">
+<description>Last Ninja </description>
+<year>19xx</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4b81ffab" name="Last Ninja (19xx)(Activision)(Disk 3 of 3)[cr Coast to Coast].dsk" offset="0" sha1="7fef40ff68f391705f5ca9ab68b9c2c2" size="143360" /></dataarea></part></software>
+<software name="LawofthecrD">
+<description>Law of the West </description>
+<year>1985</year>
+<publisher>Accolade</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="acca407e" name="Law of the West (1985)(Accolade)[cr Digital Gang].dsk" offset="0" sha1="c7aaeac03b2187ab2a45b648b10e456f" size="143360" /></dataarea></part></software>
+<software name="LeatherG">
+<description>Leather Goddesses of Phobos </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="489a78dc" name="Leather Goddesses of Phobos (1986)(Infocom).dsk" offset="0" sha1="658fdfbd842d75d1bb4cf9f031b6e689" size="143360" /></dataarea></part></software>
+<software name="LeatherGcrC">
+<description>Leather Goddesses of Phobos </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bcad921f" name="Leather Goddesses of Phobos (1986)(Infocom)[cr Coast to Coast].dsk" offset="0" sha1="ff3b58e3758b159b8ae6a88f3cfd4a5f" size="143360" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="55f1acf1" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 1 of 4)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="fdb519230056b82449d055138ccf9ed2" size="143360" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="0b0a0e4a" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 1 of 4)[cr Rocky Mountain Pirates Guild][o].dsk" offset="0" sha1="24dad0875bb0dfeb42b9bcca35fc6c66" size="143363" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d6a92d76" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 2 of 4)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="850b8eebc8894a28e2b9294307619ea5" size="143360" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="4740e547" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 2 of 4)[cr Rocky Mountain Pirates Guild][o].dsk" offset="0" sha1="202db951795502d4bb0f2a0c0adf0ba4" size="143363" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e0abb972" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 3 of 4)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="76c9b8d4eabc90ed4039aca968d86675" size="143360" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="bb6a639f" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 3 of 4)[cr Rocky Mountain Pirates Guild][o].dsk" offset="0" sha1="6141bc8bc0a8969de1103355699c1050" size="143363" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ee510875" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 4 of 4)[cr Rocky Mountain Pirates Guild].dsk" offset="0" sha1="d075ce4a31d4eded24109723fab1ebcf" size="143360" /></dataarea></part></software>
+<software name="LegacyofcrR">
+<description>Legacy of Ancients </description>
+<year>1987</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="1e93f1ef" name="Legacy of Ancients (1987)(Electronic Arts)(Disk 4 of 4)[cr Rocky Mountain Pirates Guild][o].dsk" offset="0" sha1="e66cdc68412fedaaf03d42978b19370b" size="143363" /></dataarea></part></software>
+<software name="Legendof">
+<description>Legend of Blacksilver, The </description>
+<year>1989</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="75a6ba74" name="Legend of Blacksilver, The (1989)(Quest Software)(Disk 1 of 4).dsk" offset="0" sha1="8347b7531e62aec40c1ddf17b053a1ed" size="143360" /></dataarea></part></software>
+<software name="Legendof">
+<description>Legend of Blacksilver, The </description>
+<year>1989</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="59050c46" name="Legend of Blacksilver, The (1989)(Quest Software)(Disk 2 of 4).dsk" offset="0" sha1="f0098bebbee7e76cc502b16b55c0cc76" size="143360" /></dataarea></part></software>
+<software name="Legendof">
+<description>Legend of Blacksilver, The </description>
+<year>1989</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0f9a5e2e" name="Legend of Blacksilver, The (1989)(Quest Software)(Disk 3 of 4).dsk" offset="0" sha1="049750d4d98a8ecf27912161e77e9d7d" size="143360" /></dataarea></part></software>
+<software name="Legendof">
+<description>Legend of Blacksilver, The </description>
+<year>1989</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d68acda4" name="Legend of Blacksilver, The (1989)(Quest Software)(Disk 4 of 4).dsk" offset="0" sha1="3e00d4da6351d5431eab27e3965741af" size="143360" /></dataarea></part></software>
+<software name="LeisureScrB">
+<description>Leisure Suit Larry I </description>
+<year>19xx</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8d34211f" name="Leisure Suit Larry I (19xx)(Sierra)(Disk 1 of 3 Side A)[cr Blade][b].dsk" offset="0" sha1="7329ff45280e00884eab7b474ef8e035" size="143360" /></dataarea></part></software>
+<software name="LeisureScrB">
+<description>Leisure Suit Larry I </description>
+<year>19xx</year>
+<publisher>Disk 1 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1009453" name="Leisure Suit Larry I (19xx)(Sierra)(Disk 1 of 3 Side B)[cr Blade][b].dsk" offset="0" sha1="ee50f80371dd5a4123accf80d17a3b41" size="143360" /></dataarea></part></software>
+<software name="LeisureScrB">
+<description>Leisure Suit Larry I </description>
+<year>19xx</year>
+<publisher>Disk 2 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a39c47dd" name="Leisure Suit Larry I (19xx)(Sierra)(Disk 2 of 3 Side A)[cr Blade][b].dsk" offset="0" sha1="a0e4740aa62dc8b54aa1fb212f037dd2" size="143360" /></dataarea></part></software>
+<software name="LeisureScrB">
+<description>Leisure Suit Larry I </description>
+<year>19xx</year>
+<publisher>Disk 2 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dfd7d2cb" name="Leisure Suit Larry I (19xx)(Sierra)(Disk 2 of 3 Side B)[cr Blade][b].dsk" offset="0" sha1="15b2eca2e41f85fd00df29003887c090" size="143360" /></dataarea></part></software>
+<software name="LeisureScrB">
+<description>Leisure Suit Larry I </description>
+<year>19xx</year>
+<publisher>Disk 3 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8794243b" name="Leisure Suit Larry I (19xx)(Sierra)(Disk 3 of 3 Side A)[cr Blade][b].dsk" offset="0" sha1="2b3bd8a509132e61f721116794b1178b" size="143360" /></dataarea></part></software>
+<software name="LodeRunncrC">
+<description>Lode Runner </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8323d0b5" name="Lode Runner (1983)(Broderbund)[cr Clean Crack Band].dsk" offset="0" sha1="44fe1abcd7e00c7ac7c3b1ecc75b36cb" size="143360" /></dataarea></part></software>
+<software name="LodeRunncrC">
+<description>Lode Runner </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9e195aa6" name="Lode Runner (1983)(Broderbund)[cr Clean Crack Band][a].dsk" offset="0" sha1="539e59719583081741bac76452907b4f" size="143360" /></dataarea></part></software>
+<software name="LordofthcrB">
+<description>Lord of the Flies </description>
+<year>198x</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cf0a6f06" name="Lord of the Flies (198x)(CBS Software - Media Basics)(Side A)[cr Bunnymen].dsk" offset="0" sha1="5f2fa6408b67a3288dd49b2e1d39d661" size="143360" /></dataarea></part></software>
+<software name="LordofthcrB">
+<description>Lord of the Flies </description>
+<year>198x</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6281b452" name="Lord of the Flies (198x)(CBS Software - Media Basics)(Side B)[cr Bunnymen].dsk" offset="0" sha1="445e3146c33e2da07bae79882674e5e4" size="143360" /></dataarea></part></software>
+<software name="LurkingH">
+<description>Lurking Horror, The </description>
+<year>1987</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bcddc13b" name="Lurking Horror, The (1987)(Infocom).dsk" offset="0" sha1="d17bc88c8170b5f63ff55d5ae723a58f" size="143360" /></dataarea></part></software>
+<software name="Mabel'sMcrM">
+<description>Mabel's Mansion </description>
+<year>19xx</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b8337506" name="Mabel's Mansion (19xx)(Datamost)[cr Mr. Krac-Man][b].dsk" offset="0" sha1="e61bad7475ba1da8def69778596ea237" size="143360" /></dataarea></part></software>
+<software name="MakeYourcrF">
+<description>Make Your Own Murder Party </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="61ca4000" name="Make Your Own Murder Party (1986)(Electronic Arts)(Side A)[cr First Class].dsk" offset="0" sha1="8301602518a2bf1d04777a6a54572987" size="143360" /></dataarea></part></software>
+<software name="MakeYourcrF">
+<description>Make Your Own Murder Party </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3f887662" name="Make Your Own Murder Party (1986)(Electronic Arts)(Side B)[cr First Class].dsk" offset="0" sha1="ab284a66f7796c3b5e76e7e9c1747fd8" size="143360" /></dataarea></part></software>
+<software name="MandragocrA">
+<description>Mandragore </description>
+<year>1985</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83658d84" name="Mandragore (1985)(Infogrames)(fr)(Disk 1 of 2)[cr A.B.C.].dsk" offset="0" sha1="b983e7a25ba237255f47ddc8606396e6" size="143360" /></dataarea></part></software>
+<software name="MandragocrA">
+<description>Mandragore </description>
+<year>1985</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f25ba90d" name="Mandragore (1985)(Infogrames)(fr)(Disk 2 of 2)[cr A.B.C.].dsk" offset="0" sha1="11e73deb4162b23fd92adb093036a228" size="143360" /></dataarea></part></software>
+<software name="ManiacMa">
+<description>Maniac Mansion </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6a61ff48" name="Maniac Mansion (1987)(LFL)(Side A).dsk" offset="0" sha1="e017630555f90e32d1b3a4c1c301ab77" size="143360" /></dataarea></part></software>
+<software name="ManiacMaa">
+<description>Maniac Mansion </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="15798a84" name="Maniac Mansion (1987)(LFL)(Side A)[a].dsk" offset="0" sha1="394d0b39eb51ee850c45c31591f1bc7c" size="143360" /></dataarea></part></software>
+<software name="ManiacMacrB">
+<description>Maniac Mansion </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cf398ef0" name="Maniac Mansion (1987)(LFL)(Side A)[cr Blade].dsk" offset="0" sha1="d006382294a92af9a9733c2c2ff9be4c" size="143360" /></dataarea></part></software>
+<software name="ManiacMa">
+<description>Maniac Mansion </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="de0a27e2" name="Maniac Mansion (1987)(LFL)(Side B).dsk" offset="0" sha1="fd7e3593570af7bcbfbfd030063849d2" size="143360" /></dataarea></part></software>
+<software name="MarbleMaa2">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5bbb828f" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side A)[a2].dsk" offset="0" sha1="edd28799e46d09789683664fbcea7a63" size="143360" /></dataarea></part></software>
+<software name="MarbleMaa3">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eebf2c0e" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side A)[a3].dsk" offset="0" sha1="f8844411d393eb12ab4d5ef39917d53e" size="143360" /></dataarea></part></software>
+<software name="MarbleMaa">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ffb2fc00" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side A)[a].dsk" offset="0" sha1="701aa95808a0b5d2bd9f54f85abc4887" size="143360" /></dataarea></part></software>
+<software name="MarbleMacrF">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d2027240" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side A)[cr First Class].dsk" offset="0" sha1="4d840c9f0dea1181d1cc3fb01a46325e" size="143360" /></dataarea></part></software>
+<software name="MarbleMa">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3b98e16d" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side B).dsk" offset="0" sha1="e7d37c6c36498d01479c869044933a76" size="143360" /></dataarea></part></software>
+<software name="MarbleMacrF">
+<description>Marble Madness </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="61c658bb" name="Marble Madness (1986)(Atari Games - Electronics Arts)(Side B)[cr First Class].dsk" offset="0" sha1="3b680f9f69319d1c5a43bc4089da2b3e" size="143360" /></dataarea></part></software>
+<software name="MasqueracrC">
+<description>Masquerade </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="398b2bd7" name="Masquerade (1984)(American Eagle Software)(Side A)[cr Clean Crack Band].dsk" offset="0" sha1="fb00bc430c28d15ff24f9ab684394ac8" size="143360" /></dataarea></part></software>
+<software name="MasqueracrC">
+<description>Masquerade </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2d58e83c" name="Masquerade (1984)(American Eagle Software)(Side B)[cr Clean Crack Band].dsk" offset="0" sha1="b4a427d70f6096eaba521298e10632cc" size="143360" /></dataarea></part></software>
+<software name="MechBrigRDO">
+<description>Mech Brigade </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ecd92c4c" name="Mech Brigade (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="5381e5dc58f5963230ff6621f299bf6a" size="143360" /></dataarea></part></software>
+<software name="MechBrigRDO">
+<description>Mech Brigade </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c5ba69d7" name="Mech Brigade (1985)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="ad2fcc3bda82f69527b8b1cf0b436d67" size="143360" /></dataarea></part></software>
+<software name="MemelesP">
+<description>Meme les Pommes de Terre Ont des Yeux </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4f3c1cf7" name="Meme les Pommes de Terre Ont des Yeux (1985)(Froggy Software)(fr)(Side A).dsk" offset="0" sha1="f1fd3a9ef3e61b1bbe4784d790bbfe1a" size="143360" /></dataarea></part></software>
+<software name="MemelesP">
+<description>Meme les Pommes de Terre Ont des Yeux </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22ec303c" name="Meme les Pommes de Terre Ont des Yeux (1985)(Froggy Software)(fr)(Side B).dsk" offset="0" sha1="f7348e2c3bf6d3a8fd41181d3a213623" size="143360" /></dataarea></part></software>
+<software name="MicroHabcrH">
+<description>Micro Habitats Contruction Set </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e6e7bc20" name="Micro Habitats Contruction Set (19xx)(-)[cr Hi-Res Hijackers].dsk" offset="0" sha1="df07930e92bc0d56f928c9f7824cc80f" size="143360" /></dataarea></part></software>
+<software name="MicroLeacrR">
+<description>Micro League Baseball </description>
+<year>1984</year>
+<publisher>Mico League Sports Association</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b1a1f9f4" name="Micro League Baseball (1984)(Mico League Sports Association)[cr Racketeers].dsk" offset="0" sha1="2ddb4b553a0deb1ad8ec9d25fc4d4665" size="143360" /></dataarea></part></software>
+<software name="Microbe-">
+<description>Microbe - The Tinkerer Jgv Dick </description>
+<year>1982</year>
+<publisher>Synergistic Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c2bf06a0" name="Microbe - The Tinkerer Jgv Dick (1982)(Synergistic Software).dsk" offset="0" sha1="37a7e2253fd73956a83981c56e758259" size="143360" /></dataarea></part></software>
+<software name="MicrobeT">
+<description>Microbe, The Anatomical Adventure </description>
+<year>1982</year>
+<publisher>Synergistic Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="49b2c874" name="Microbe, The Anatomical Adventure (1982)(Synergistic Software).dsk" offset="0" sha1="d473b01b29523d806cd0e6067bab4229" size="143360" /></dataarea></part></software>
+<software name="Microwavcr">
+<description>Microwave </description>
+<year>1982</year>
+<publisher>Cavalier Computer</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8e2f62b7" name="Microwave (1982)(Cavalier Computer)[cr].dsk" offset="0" sha1="4181742cfd5da64d8142862073ecdb79" size="143360" /></dataarea></part></software>
+<software name="MightAndb">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="56e35761" name="Might And Magic - Book One (1986)(New World Computing)(Disk 1 of 4)[b].dsk" offset="0" sha1="e7e3ee212ea8ae0adf43d99f2588feed" size="143360" /></dataarea></part></software>
+<software name="MightAndb">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="122c32d7" name="Might And Magic - Book One (1986)(New World Computing)(Disk 2 of 4)[b].dsk" offset="0" sha1="da63ea176018ea639d0e9c16302d0c71" size="143360" /></dataarea></part></software>
+<software name="MightAndcrF">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2ca4fd2e" name="Might And Magic - Book One (1986)(New World Computing)(Disk 2 of 4)[cr First Class].dsk" offset="0" sha1="47b313e6aae6bab3bcd2ff27f6015a68" size="143360" /></dataarea></part></software>
+<software name="MightAndb">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d763120d" name="Might And Magic - Book One (1986)(New World Computing)(Disk 3 of 4)[b].dsk" offset="0" sha1="7877409c934cfe5c2c08a9938fe0a39b" size="143360" /></dataarea></part></software>
+<software name="MightAndcrF">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="edd7f435" name="Might And Magic - Book One (1986)(New World Computing)(Disk 3 of 4)[cr First Class].dsk" offset="0" sha1="e84b69df0fa5fac4b38772bb26fb0d8e" size="143360" /></dataarea></part></software>
+<software name="MightAndb">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8403e653" name="Might And Magic - Book One (1986)(New World Computing)(Disk 4 of 4)[b].dsk" offset="0" sha1="b0f4c00eb097c0019c7ca56998def357" size="143360" /></dataarea></part></software>
+<software name="MightAndcrF">
+<description>Might And Magic - Book One </description>
+<year>1986</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2d0c76b8" name="Might And Magic - Book One (1986)(New World Computing)(Disk 4 of 4)[cr First Class].dsk" offset="0" sha1="e1fb64daa73d59f62fd8e074563a8d82" size="143360" /></dataarea></part></software>
+<software name="MindFore">
+<description>Mind Forever Voyaging, A </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3ac9d7d8" name="Mind Forever Voyaging, A (1985)(Infocom)(Side A).dsk" offset="0" sha1="99c80cf510356dbb50dedbafd05a2ae4" size="143360" /></dataarea></part></software>
+<software name="MindshadcrB">
+<description>Mindshadow </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d3b58689" name="Mindshadow (1984)(Activision)(Side A)[cr Black Bag].dsk" offset="0" sha1="fa1c0e94be270723eb8601d36cc67cb3" size="143360" /></dataarea></part></software>
+<software name="MindshadcrB">
+<description>Mindshadow </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cb161912" name="Mindshadow (1984)(Activision)(Side B)[cr Black Bag].dsk" offset="0" sha1="4f50a0c84ef31e8d6c315f31a4c1843c" size="143360" /></dataarea></part></software>
+<software name="MindwheecrD">
+<description>Mindwheel </description>
+<year>1984</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aa043b28" name="Mindwheel (1984)(Synapse Software)(Disk 1 of 4)[cr Disk Jockey].dsk" offset="0" sha1="35aa9766c438a23d14a82e47f508f6a9" size="143360" /></dataarea></part></software>
+<software name="MindwheecrD">
+<description>Mindwheel </description>
+<year>1984</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4dd13cdc" name="Mindwheel (1984)(Synapse Software)(Disk 2 of 4)[cr Disk Jockey].dsk" offset="0" sha1="82764b5e4b4b23d3984b1fbcfee3c58b" size="143360" /></dataarea></part></software>
+<software name="MindwheecrD">
+<description>Mindwheel </description>
+<year>1984</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="610707c1" name="Mindwheel (1984)(Synapse Software)(Disk 3 of 4)[cr Disk Jockey].dsk" offset="0" sha1="ee7cdc35091bf0d813800df42032fe17" size="143360" /></dataarea></part></software>
+<software name="MindwheecrD">
+<description>Mindwheel </description>
+<year>1984</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac9db199" name="Mindwheel (1984)(Synapse Software)(Disk 4 of 4)[cr Disk Jockey].dsk" offset="0" sha1="c44f3730864367b6c99c18b35ae89526" size="143360" /></dataarea></part></software>
+<software name="Miner204">
+<description>Miner 2049er </description>
+<year>1982</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8c16b767" name="Miner 2049er (1982)(Micro Fun).dsk" offset="0" sha1="2969e58e97abb9edf0a4e3e5a01861c4" size="143360" /></dataarea></part></software>
+<software name="Miner204a2">
+<description>Miner 2049er </description>
+<year>1982</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f22ae196" name="Miner 2049er (1982)(Micro Fun)[a2].dsk" offset="0" sha1="4d638a8c2b9a2bbaa717fdfea175c1dc" size="143360" /></dataarea></part></software>
+<software name="Miner204a3">
+<description>Miner 2049er </description>
+<year>1982</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ceb178c2" name="Miner 2049er (1982)(Micro Fun)[a3].dsk" offset="0" sha1="80bfcaa84a9b944b574c0bc2c19b0738" size="143360" /></dataarea></part></software>
+<software name="Miner204a">
+<description>Miner 2049er </description>
+<year>1982</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d823fbbb" name="Miner 2049er (1982)(Micro Fun)[a].dsk" offset="0" sha1="1486f320b895f2bc0c23fae49a1911f9" size="143360" /></dataarea></part></software>
+<software name="Miner204crS">
+<description>Miner 2049er </description>
+<year>1982</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="de017297" name="Miner 2049er (1982)(Micro Fun)[cr Super Pirates][o].dsk" offset="0" sha1="58f6b97f9e96bf574a601962b7f05c8b" size="143488" /></dataarea></part></software>
+<software name="MinerIIcrD">
+<description>Miner II </description>
+<year>1984</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="394e59d9" name="Miner II (1984)(Micro Fun)[cr Disk Destroyer - Mage].dsk" offset="0" sha1="b5e5b5a90f96dd48342708d745ab52a4" size="143360" /></dataarea></part></software>
+<software name="MinerIIcrD">
+<description>Miner II </description>
+<year>1984</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="02ea00c2" name="Miner II (1984)(Micro Fun)[cr Disk Destroyer - Mage][o].dsk" offset="0" sha1="503cebb0d334a2b409cf87af5001e072" size="143488" /></dataarea></part></software>
+<software name="MinerIIcrI">
+<description>Miner II </description>
+<year>1984</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="270fbb6b" name="Miner II (1984)(Micro Fun)[cr International Cracking Club].dsk" offset="0" sha1="bf03cd41524ff098a5db108444a4ce38" size="143360" /></dataarea></part></software>
+<software name="MinesofTRDO">
+<description>Mines of Titan </description>
+<year>1989</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3752cffe" name="Mines of Titan (1989)(Infocom)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="994ce437eb19b35e6cb509785e74a775" size="143360" /></dataarea></part></software>
+<software name="MinesofTRDO">
+<description>Mines of Titan </description>
+<year>1989</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e8b263f0" name="Mines of Titan (1989)(Infocom)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="83baefae564be6e564d7c01911832fa6" size="143360" /></dataarea></part></software>
+<software name="Ming'sChcrK">
+<description>Ming's Challenge </description>
+<year>1982</year>
+<publisher>Mike Livesay</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="715b2090" name="Ming's Challenge (1982)(Mike Livesay)[cr Krakowicz].dsk" offset="0" sha1="a51333a32e755a29306fb6df8ab8ed4b" size="143360" /></dataarea></part></software>
+<software name="Mini-Zor">
+<description>Mini-Zork I - The Great Underground Empire </description>
+<year>1988</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9d08fc0e" name="Mini-Zork I - The Great Underground Empire (1988)(Infocom).dsk" offset="0" sha1="0d7abb0de48204dd3e773a22e3d11829" size="143360" /></dataarea></part></software>
+<software name="MissionE">
+<description>Mission Escape! </description>
+<year>1982</year>
+<publisher>Micro-Sparc</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="37c676b1" name="Mission Escape! (1982)(Micro-Sparc).dsk" offset="0" sha1="672a5fe9af14a74310b714afcc1e636c" size="143360" /></dataarea></part></software>
+<software name="MixedUpMb">
+<description>Mixed Up Mother Goose </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2239a1c6" name="Mixed Up Mother Goose (1987)(Sierra On-Line)(Disk 1 of 2 Side A)[b].dsk" offset="0" sha1="50522929bca23e0101dc8d4ae02982d3" size="143360" /></dataarea></part></software>
+<software name="MixedUpMb">
+<description>Mixed Up Mother Goose </description>
+<year>1987</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6dc1b397" name="Mixed Up Mother Goose (1987)(Sierra On-Line)(Disk 1 of 2 Side B)[b][DOS].dsk" offset="0" sha1="3aa8a4d7ec3bceaa23d4b929b6c930d2" size="143360" /></dataarea></part></software>
+<software name="MixedUpMb">
+<description>Mixed Up Mother Goose </description>
+<year>1987</year>
+<publisher>Disk 2 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83f5d04a" name="Mixed Up Mother Goose (1987)(Sierra On-Line)(Disk 2 of 2 Side A)[b].dsk" offset="0" sha1="800cdca432dbe127044434291a66f61e" size="143360" /></dataarea></part></software>
+<software name="MixedUpMb">
+<description>Mixed Up Mother Goose </description>
+<year>1987</year>
+<publisher>Disk 2 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="51c16793" name="Mixed Up Mother Goose (1987)(Sierra On-Line)(Disk 2 of 2 Side B)[b].dsk" offset="0" sha1="b11541a6652b4bb2ef6050684a31051d" size="143360" /></dataarea></part></software>
+<software name="MontezumcrB">
+<description>Montezuma's Revenge </description>
+<year>1984</year>
+<publisher>Parker Brothers</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e17d587" name="Montezuma's Revenge (1984)(Parker Brothers)[cr Blade][b].dsk" offset="0" sha1="1d81474d9c183646c854b23679654b9b" size="143360" /></dataarea></part></software>
+<software name="MontyPla">
+<description>Monty Plays Scrabble </description>
+<year>1980</year>
+<publisher>Ritam</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9a056e17" name="Monty Plays Scrabble (1980)(Ritam).dsk" offset="0" sha1="767685c2c1e9b3a42acd9c64108360cc" size="143360" /></dataarea></part></software>
+<software name="MoonPatrcrC">
+<description>Moon Patrol </description>
+<year>1983</year>
+<publisher>Atari</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="08d0b74e" name="Moon Patrol (1983)(Atari)[cr Clean Crack Band].dsk" offset="0" sha1="15721f8e994c02f979f9ff7b723a3f70" size="143360" /></dataarea></part></software>
+<software name="Moonmist">
+<description>Moonmist </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="85f72248" name="Moonmist (1986)(Infocom).dsk" offset="0" sha1="8f3cff31aeedc790bcf1bf9c99b3fdf8" size="143360" /></dataarea></part></software>
+<software name="MoonmisthRo">
+<description>Moonmist </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac3c4088" name="Moonmist (1986)(Infocom)[h Rom Chip - Surgeon].dsk" offset="0" sha1="f60dd1aa9aac38d2486c43f458cdcca8" size="143360" /></dataarea></part></software>
+<software name="MoonmisthRo">
+<description>Moonmist </description>
+<year>1986</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1b34f9ac" name="Moonmist (1986)(Infocom)[h Rom Chip - Surgeon][a].dsk" offset="0" sha1="ef86929297d3528cde3fa612abca79fd" size="143360" /></dataarea></part></software>
+<software name="MouseBudcrD">
+<description>Mouse Budget </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="57f04506" name="Mouse Budget (1985)(Version Soft)(Side A)[cr Digital Gang][PASCAL].dsk" offset="0" sha1="e556d0d22e0382d47a483bb30c9c7930" size="143360" /></dataarea></part></software>
+<software name="MouseBudcrD">
+<description>Mouse Budget </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="489fdba7" name="Mouse Budget (1985)(Version Soft)(Side B)[cr Digital Gang][PASCAL].dsk" offset="0" sha1="1910ed030095d97f3b263dbc2fc02cc7" size="143360" /></dataarea></part></software>
+<software name="Mr.Do!crB">
+<description>Mr. Do! </description>
+<year>1985</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="195fe5fb" name="Mr. Do! (1985)(Datasoft)[cr Black Bag][o].dsk" offset="0" sha1="e39df4a7d4164aae7400a55b039eac5a" size="143488" /></dataarea></part></software>
+<software name="Mr.Robotb">
+<description>Mr. Robot and his Robot Factory </description>
+<year>1984</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8704c95e" name="Mr. Robot and his Robot Factory (1984)(Datamost)[b].dsk" offset="0" sha1="346f0ebd57d1daa005fa88c0b47cc1fb" size="143360" /></dataarea></part></software>
+<software name="MurdeBer">
+<description>Mur de Berlin Va Sauter, Le </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9adc2d9a" name="Mur de Berlin Va Sauter, Le (1985)(Froggy Software)(fr)(Side A).dsk" offset="0" sha1="6da68c28733fdcec1d46c9e2e750d023" size="143360" /></dataarea></part></software>
+<software name="MurdeBer">
+<description>Mur de Berlin Va Sauter, Le </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3c089aba" name="Mur de Berlin Va Sauter, Le (1985)(Froggy Software)(fr)(Side B).dsk" offset="0" sha1="1b26e8eeb7372f3cd81db5bea9d2c7e2" size="143360" /></dataarea></part></software>
+<software name="MurderOncrH">
+<description>Murder On the Zinderneuf </description>
+<year>1983</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ccaeb134" name="Murder On the Zinderneuf (1983)(Electronic Arts)[cr High Society].dsk" offset="0" sha1="d568c9b385abbb55c3d99db795ad9b7a" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Boot</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="158a5bdf" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 1 of 6)(Boot).dsk" offset="0" sha1="5d4a0bf1aef112455379d2d7f2931b5f" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Program</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="56e390fb" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 2 of 6)(Program).dsk" offset="0" sha1="fea311108bfacb654340db16b82dcd1e" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Dungeons</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="20b254e0" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 3 of 6)(Dungeons).dsk" offset="0" sha1="9cf516839c65bd56cb22378136d7b36e" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Towns</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1cbb1cb3" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 4 of 6)(Towns).dsk" offset="0" sha1="6c06ad9ca97c14c3254dbb235bfb14a1" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Outside</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1cf09583" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 5 of 6)(Outside).dsk" offset="0" sha1="6eafbf79452443a1640a1df2fdb711f9" size="143360" /></dataarea></part></software>
+<software name="Muryaden">
+<description>Muryaden II v1.40 </description>
+<year>1991</year>
+<publisher>Original Maps</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="09f2f620" name="Muryaden II v1.40 (1991)(Elrik - Deckard)(fr)(Disk 6 of 6)(Original Maps).dsk" offset="0" sha1="47eec057f1652073b0c9632f2f4891fc" size="143360" /></dataarea></part></software>
+<software name="MysteryM">
+<description>Mystery Master - Murder By the Dozen </description>
+<year>1983</year>
+<publisher>CBS Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d01cac9d" name="Mystery Master - Murder By the Dozen (1983)(CBS Software).dsk" offset="0" sha1="15b2e9da7e30e552219fff7a4d7abdad" size="143360" /></dataarea></part></software>
+<software name="Nam">
+<description>Nam </description>
+<year>1986</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="160a0751" name="Nam (1986)(SSI).dsk" offset="0" sha1="5e6f6f8f29e2b05fdedf0a23f6ba6105" size="143360" /></dataarea></part></software>
+<software name="NapoleonRDO">
+<description>Napoleon's Campaigns 1813 &amp; 1815 </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="db6e1c68" name="Napoleon's Campaigns 1813 &amp; 1815 (1981)(SSI)[RDOS].dsk" offset="0" sha1="a6c6ec8039d20729418f6c682cec524c" size="143360" /></dataarea></part></software>
+<software name="NatoCommcrR">
+<description>Nato Commander </description>
+<year>1984</year>
+<publisher>Microprose</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b0cf0819" name="Nato Commander (1984)(Microprose)[cr Racketeers].dsk" offset="0" sha1="cd38fc1dfb724a9e6c68794f82addc7b" size="143360" /></dataarea></part></software>
+<software name="Neon">
+<description>Neon </description>
+<year>1983</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="35d2c9c4" name="Neon (1983)(Datamost).dsk" offset="0" sha1="e2e1ae90ef33a2c1cc2a4284f3511ef8" size="143360" /></dataarea></part></software>
+<software name="NeverendcrD">
+<description>Neverending Story, The </description>
+<year>1985</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4a1011e5" name="Neverending Story, The (1985)(Datasoft)[cr Digital Gang].dsk" offset="0" sha1="2591bb1720b6b37a14db81dcf6231b87" size="143360" /></dataarea></part></software>
+<software name="NordAndB">
+<description>Nord And Bert Couldn't Make Head Or Tail of It </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="75b9c298" name="Nord And Bert Couldn't Make Head Or Tail of It (1987)(Infocom)(Side A).dsk" offset="0" sha1="57b16c9b91db8600c903a762b930048f" size="143360" /></dataarea></part></software>
+<software name="NordAndBa">
+<description>Nord And Bert Couldn't Make Head Or Tail of It </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e95a62c7" name="Nord And Bert Couldn't Make Head Or Tail of It (1987)(Infocom)(Side A)[a].dsk" offset="0" sha1="bcfaf40fc0d80f050680b2fbdfaf1b8f" size="143360" /></dataarea></part></software>
+<software name="NorthAtlRDO">
+<description>North Atlantic 86 </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fb670cc8" name="North Atlantic 86 (1983)(SSI)[RDOS].dsk" offset="0" sha1="99121855439e7773656952e14b4a84e3" size="143360" /></dataarea></part></software>
+<software name="ObjectivRDO">
+<description>Objective Kursk </description>
+<year>1984</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="782429c3" name="Objective Kursk (1984)(SSI)[RDOS].dsk" offset="0" sha1="a5eaaf14a17c23b0ebdb2fbfd90bf15d" size="143360" /></dataarea></part></software>
+<software name="OperatioRDO">
+<description>Operation Market Garden </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac1bedda" name="Operation Market Garden (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="4d8f4f4f33f8a4a4314ffe110f9ad2cd" size="143360" /></dataarea></part></software>
+<software name="OperatioRDO">
+<description>Operation Market Garden </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5bdbb4a1" name="Operation Market Garden (1985)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="442695bc7cdb6e275d6ea66302138cf1" size="143360" /></dataarea></part></software>
+<software name="OtherSidcrM">
+<description>Other Side, The </description>
+<year>1985</year>
+<publisher>Tom Snider</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9f60779f" name="Other Side, The (1985)(Tom Snider)[cr Man O War].dsk" offset="0" sha1="718dd822280ddfb30f3283cce1808dea" size="143360" /></dataarea></part></software>
+<software name="Overrun-cr6">
+<description>Overrun - Europe v1.0 </description>
+<year>1988</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b8bff96f" name="Overrun - Europe v1.0 (1988)(SSI)(Disk 1 of 2)[cr 6502 Crew][RDOS].dsk" offset="0" sha1="6b1809f0f211260dd2d6842e59ac6abd" size="143360" /></dataarea></part></software>
+<software name="Overrun-cr6">
+<description>Overrun - Europe v1.0 </description>
+<year>1988</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="75256558" name="Overrun - Europe v1.0 (1988)(SSI)(Disk 2 of 2)[cr 6502 Crew][RDOS].dsk" offset="0" sha1="d0e745a00d6b2bc0a58c0ad07a52624e" size="143360" /></dataarea></part></software>
+<software name="Overrun-RDO">
+<description>Overrun - Europe v1.0 </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ab087b7" name="Overrun - Europe v1.0 (1988)(SSI)[RDOS].dsk" offset="0" sha1="bb3c8183671aac8529f1d3aab7a77620" size="143360" /></dataarea></part></software>
+<software name="PanzerStRDO">
+<description>Panzer Strike Africa </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4ca14093" name="Panzer Strike Africa (1987)(SSI)[RDOS].dsk" offset="0" sha1="cf0e81fdc4737103dbd66fcb70b5ad50" size="143360" /></dataarea></part></software>
+<software name="PanzerStRDO">
+<description>Panzer Strike East </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0076aca7" name="Panzer Strike East (1987)(SSI)[RDOS].dsk" offset="0" sha1="bf192b74c6c05e8f40b537576378cc1c" size="143360" /></dataarea></part></software>
+<software name="PanzerSt">
+<description>Panzer Strike Scenery </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c457a7a5" name="Panzer Strike Scenery (1987)(SSI).dsk" offset="0" sha1="565b0920a9b80c396fefde521de52fb7" size="143360" /></dataarea></part></software>
+<software name="PanzerStRDO">
+<description>Panzer Strike West </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3ff822dc" name="Panzer Strike West (1987)(SSI)[RDOS].dsk" offset="0" sha1="37387d0e5f7003e5f888ede0705ddd7e" size="143360" /></dataarea></part></software>
+<software name="ParanoiacrB">
+<description>Paranoiak </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0e664d69" name="Paranoiak (1984)(Froggy Software)(fr)(Side A)[cr Binary Crack Band].dsk" offset="0" sha1="9771f313dda522e8c65407e94c173fb2" size="143360" /></dataarea></part></software>
+<software name="ParanoiacrB">
+<description>Paranoiak </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="62cc6021" name="Paranoiak (1984)(Froggy Software)(fr)(Side B)[cr Binary Crack Band].dsk" offset="0" sha1="ddc76a12c8dcd197b8d5395bf80f9461" size="143360" /></dataarea></part></software>
+<software name="PawnThecrL">
+<description>Pawn, The </description>
+<year>1986</year>
+<publisher>Rainbird</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5677d1f6" name="Pawn, The (1986)(Rainbird)[cr L.S.D.][b].dsk" offset="0" sha1="dd03e62cc7f8d007248fe43e88a8197c" size="143360" /></dataarea></part></software>
+<software name="PhantasicrR">
+<description>Phantasie </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3f9974f2" name="Phantasie (1984)(Pioneer)(Disk 1 of 2)[cr Racketeers][RDOS].dsk" offset="0" sha1="9aa47323c742445df492f844806ac122" size="143360" /></dataarea></part></software>
+<software name="PhantasicrR">
+<description>Phantasie </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9dcb5077" name="Phantasie (1984)(Pioneer)(Disk 2 of 2)[cr Racketeers][RDOS].dsk" offset="0" sha1="69361bb75dfaf84c6282d6e4c71f2da6" size="143360" /></dataarea></part></software>
+<software name="PhantasicrL">
+<description>Phantasie II v1.0 </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="431e4b16" name="Phantasie II v1.0 (1986)(SSI)(Disk 1 of 2)[cr L.S.D.][RDOS].dsk" offset="0" sha1="83881fba7cbc7de48325143f6fa8d88f" size="143360" /></dataarea></part></software>
+<software name="PhantasiRDO">
+<description>Phantasie II v1.0 </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ffccaa45" name="Phantasie II v1.0 (1986)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="c1b9460353d88ddc4282ae13f0768826" size="143360" /></dataarea></part></software>
+<software name="PhantasicrL">
+<description>Phantasie II v1.0 </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fb987b02" name="Phantasie II v1.0 (1986)(SSI)(Disk 2 of 2)[cr L.S.D.][RDOS].dsk" offset="0" sha1="7679e69259ac1f92376e135e8610db85" size="143360" /></dataarea></part></software>
+<software name="PhantasiRDO">
+<description>Phantasie II v1.0 </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="98060749" name="Phantasie II v1.0 (1986)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="40a150dadf3b80e4b576765b4c425e2e" size="143360" /></dataarea></part></software>
+<software name="Phantasicr">
+<description>Phantasie III v1.0 </description>
+<year>1987</year>
+<publisher>Disk 1 of 3 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0b398e0e" name="Phantasie III v1.0 (1987)(SSI)(Disk 1 of 3 Side A)[cr][RDOS].dsk" offset="0" sha1="0464e10381e594712bc6aebdd6f111e7" size="143360" /></dataarea></part></software>
+<software name="Phantasicr">
+<description>Phantasie III v1.0 </description>
+<year>1987</year>
+<publisher>Disk 1 of 3 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="70e6dfd2" name="Phantasie III v1.0 (1987)(SSI)(Disk 1 of 3 Side B)[cr][RDOS].dsk" offset="0" sha1="55d014d7ab3405a66a75290ade672f99" size="143360" /></dataarea></part></software>
+<software name="Phantasicr">
+<description>Phantasie III v1.0 </description>
+<year>1987</year>
+<publisher>Dungeon</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d0a49b52" name="Phantasie III v1.0 (1987)(SSI)(Disk 2 of 3 Side A)(Dungeon)[cr][RDOS].dsk" offset="0" sha1="b5d971d0596bd77fcda50b490e6e6c64" size="143360" /></dataarea></part></software>
+<software name="Phantasicr">
+<description>Phantasie III v1.0 </description>
+<year>1987</year>
+<publisher>Player</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e5a2b9a" name="Phantasie III v1.0 (1987)(SSI)(Disk 3 of 3 Side A)(Player)[cr][RDOS].dsk" offset="0" sha1="fd884f8b19f5f2ee444ff3ff021a6f4d" size="143360" /></dataarea></part></software>
+<software name="Planetfa">
+<description>Planetfall </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dcd44739" name="Planetfall (1983)(Infocom).dsk" offset="0" sha1="1473e2da10918c0d8e90c69f20022e3a" size="143360" /></dataarea></part></software>
+<software name="Planetfaa">
+<description>Planetfall </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5f807db0" name="Planetfall (1983)(Infocom)[a].dsk" offset="0" sha1="bbed93177edd44e6a18ee579d6e81822" size="143360" /></dataarea></part></software>
+<software name="PleinsGacrB">
+<description>Pleins Gaz </description>
+<year>1986</year>
+<publisher>fr</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1847e224" name="Pleins Gaz (1986)(Froggy Software)(fr)[cr Bytlejuice][t +1].dsk" offset="0" sha1="3653a01623136449433cbfb4feff9733" size="143360" /></dataarea></part></software>
+<software name="Plundere">
+<description>Plundered Hearts </description>
+<year>1987</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="931ec635" name="Plundered Hearts (1987)(Infocom).dsk" offset="0" sha1="ac28e0a8887f9e1ac69a65ec2167c215" size="143360" /></dataarea></part></software>
+<software name="Plunderea">
+<description>Plundered Hearts </description>
+<year>1987</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8888e69d" name="Plundered Hearts (1987)(Infocom)[a].dsk" offset="0" sha1="d459a85964a8f72060cf73ad1363098c" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 1 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4da13958" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 1 of 8)[cr 6502 Crew].dsk" offset="0" sha1="71a480311eda8458cc66f9a7217e142e" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 1 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e3eed24d" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 1 of 8)[cr 6502 Crew][a].dsk" offset="0" sha1="dc2deb4539d2cb12bb5a843429ea930f" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 2 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8277521d" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 2 of 8)[cr 6502 Crew].dsk" offset="0" sha1="56a3d37c31398c7d1282076fb4247bdf" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 3 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dc77130e" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 3 of 8)[cr 6502 Crew].dsk" offset="0" sha1="99649add95b0429e9979f79853adc33f" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 4 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1d1b954b" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 4 of 8)[cr 6502 Crew].dsk" offset="0" sha1="b86faaa535f7bf7d54e60d02f3fc3e83" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 5 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2b8c7e6b" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 5 of 8)[cr 6502 Crew].dsk" offset="0" sha1="e8d3b3211bc6915315fa6e2f2ac159cd" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 6 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7002a725" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 6 of 8)[cr 6502 Crew].dsk" offset="0" sha1="a372194fdd18994b0d3a5a9b168613d0" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 7 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1ec1706" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 7 of 8)[cr 6502 Crew].dsk" offset="0" sha1="6867101533ee54796c8460223b9158af" size="143360" /></dataarea></part></software>
+<software name="PoolofRacr6">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>Disk 8 of 8</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ce508582" name="Pool of Radiance v1.1 (1989)(SSI)(Disk 8 of 8)[cr 6502 Crew].dsk" offset="0" sha1="3baca4c0ab7482947cfbddbf2338d640" size="143360" /></dataarea></part></software>
+<software name="PoolofRaSav">
+<description>Pool of Radiance v1.1 </description>
+<year>1989</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="aaba4947" name="Pool of Radiance v1.1 (1989)(SSI)[Save].dsk" offset="0" sha1="08eaa891b64439a2da35b4e3d558fb48" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 1 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="698570c5" name="Portal (1986)(Activision)(Disk 1 of 6)[cr Lot].dsk" offset="0" sha1="92c75ddc099629ff0dd9a0240be04767" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 2 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="56038539" name="Portal (1986)(Activision)(Disk 2 of 6)[cr Lot].dsk" offset="0" sha1="5d700dcfc2a75d8b618420bbafb4bc20" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 3 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="43fa124b" name="Portal (1986)(Activision)(Disk 3 of 6)[cr Lot].dsk" offset="0" sha1="119ffd820d50cb664a715ed3b243ceef" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 4 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e5e9cb8f" name="Portal (1986)(Activision)(Disk 4 of 6)[cr Lot].dsk" offset="0" sha1="7cdcdac470c76e91d36e3dc15c361e87" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 5 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="91cf679a" name="Portal (1986)(Activision)(Disk 5 of 6)[cr Lot].dsk" offset="0" sha1="e64a0f587b1591e3908b4462bebe5b87" size="143360" /></dataarea></part></software>
+<software name="PortalcrL">
+<description>Portal </description>
+<year>1986</year>
+<publisher>Disk 6 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0c431942" name="Portal (1986)(Activision)(Disk 6 of 6)[cr Lot].dsk" offset="0" sha1="18e90707eda22593033fc61c94fc8c0d" size="143360" /></dataarea></part></software>
+<software name="PresidenRDO">
+<description>President Elect v1.1 </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="271e4d89" name="President Elect v1.1 (1981)(SSI)[RDOS].dsk" offset="0" sha1="861025a5cf6059a4f6bbc086ed2a2bf5" size="143360" /></dataarea></part></software>
+<software name="PresidenRDO">
+<description>President Elect v2.0 </description>
+<year>1987</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e05a85d1" name="President Elect v2.0 (1987)(SSI)[RDOS].dsk" offset="0" sha1="8cee7b16441b2422cbf29379ff79c74b" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrB">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8e22ddbc" name="Prince of Persia (1989)(Broderbund)(Disk 1 of 3)[cr Byte Bastards].dsk" offset="0" sha1="669f3af76f364bf2c59d6bf080ff2468" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrS">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6f74218d" name="Prince of Persia (1989)(Broderbund)(Disk 1 of 3)[cr Soft Sector].dsk" offset="0" sha1="6836037acfa5d8dd5509ba19317e2d16" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrB">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 2 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b5fe2c1c" name="Prince of Persia (1989)(Broderbund)(Disk 2 of 3)[cr Byte Bastards].dsk" offset="0" sha1="cfe4523b9d3c6ca0c189e2334a9c1e30" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrS">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 2 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1b454a3f" name="Prince of Persia (1989)(Broderbund)(Disk 2 of 3)[cr Soft Sector].dsk" offset="0" sha1="ca0b55db548c078a5dfab9424c8716d3" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrB">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1274485c" name="Prince of Persia (1989)(Broderbund)(Disk 3 of 3)[cr Byte Bastards][DOS].dsk" offset="0" sha1="13150846073683ba2e4fb89d765013ba" size="143360" /></dataarea></part></software>
+<software name="PrinceofcrS">
+<description>Prince of Persia </description>
+<year>1989</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1f087e5" name="Prince of Persia (1989)(Broderbund)(Disk 3 of 3)[cr Soft Sector].dsk" offset="0" sha1="e03a129ea40a9ac516103b0d566a1181" size="143360" /></dataarea></part></software>
+<software name="ProfessiRDO">
+<description>Professional Tour Golf </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b955c1d4" name="Professional Tour Golf (1983)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="eb844acc7ce1e0e14b0571932b4e5a6e" size="143360" /></dataarea></part></software>
+<software name="ProfessiRDO">
+<description>Professional Tour Golf </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="57644a40" name="Professional Tour Golf (1983)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="1a321deb5934d33f03419a444b1ff886" size="143360" /></dataarea></part></software>
+<software name="ProjectS">
+<description>Project Space Station </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="554d19cc" name="Project Space Station (1987)(Avantage)(Side A).dsk" offset="0" sha1="031660b909c9a6c79b214eba9c5c926b" size="143360" /></dataarea></part></software>
+<software name="ProjectScrF">
+<description>Project Space Station </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b2c7d20c" name="Project Space Station (1987)(Avantage)(Side A)[cr Five Star].dsk" offset="0" sha1="20efaed531a2fb94e118ed5b1d2f0425" size="143360" /></dataarea></part></software>
+<software name="ProjectS">
+<description>Project Space Station </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3378c8ec" name="Project Space Station (1987)(Avantage)(Side B).dsk" offset="0" sha1="5c26396de842fe986fc0473ecc8eaa6e" size="143360" /></dataarea></part></software>
+<software name="ProjectScrF">
+<description>Project Space Station </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f7b1c3e6" name="Project Space Station (1987)(Avantage)(Side B)[cr Five Star].dsk" offset="0" sha1="8f66e66de70cb8e592c9c03d96ff6d06" size="143360" /></dataarea></part></software>
+<software name="PursuitoRDO">
+<description>Pursuit of the Graf Spee </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="45495d3b" name="Pursuit of the Graf Spee (1982)(SSI)[RDOS].dsk" offset="0" sha1="079a3bd0eaa6b348094570308901b391" size="143360" /></dataarea></part></software>
+<software name="Qix">
+<description>Qix </description>
+<year>1989</year>
+<publisher>Taito</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f4612a2c" name="Qix (1989)(Taito).dsk" offset="0" sha1="535ae811f7caed97f9455a7110fdd128" size="143360" /></dataarea></part></software>
+<software name="QixcrB">
+<description>Qix </description>
+<year>1989</year>
+<publisher>Taito</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="719c567c" name="Qix (1989)(Taito)[cr Blade].dsk" offset="0" sha1="70f333cfd32abb90c7c17bfe3d38db41" size="143360" /></dataarea></part></software>
+<software name="QueenofH">
+<description>Queen of Hearts </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="14dd92b8" name="Queen of Hearts (1983)(SSI).dsk" offset="0" sha1="ee7f458e141a079ff377f34f98b9e969" size="143360" /></dataarea></part></software>
+<software name="QueenofHcrM">
+<description>Queen of Hearts </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8ef3cb5f" name="Queen of Hearts (1983)(SSI)[cr Mr. Krac-Man][RDOS].dsk" offset="0" sha1="484f1f6de359133342375ab418031a94" size="143360" /></dataarea></part></software>
+<software name="QueenofPb">
+<description>Queen of Phobos, The </description>
+<year>1982</year>
+<publisher>Phoenix Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d9da714a" name="Queen of Phobos, The (1982)(Phoenix Software)[b][PASCAL].dsk" offset="0" sha1="ce8819de942ddadc1d4f2e44ce15e551" size="143360" /></dataarea></part></software>
+<software name="QuestprocrB">
+<description>Questprobe 3 - The Fantastic Four </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d0c16297" name="Questprobe 3 - The Fantastic Four (1985)(Adventure Soft)(Side A)[cr Blade].dsk" offset="0" sha1="55b92ebb6538a80cb92782a758de8f9b" size="143360" /></dataarea></part></software>
+<software name="QuestprocrB">
+<description>Questprobe 3 - The Fantastic Four </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="30c374b3" name="Questprobe 3 - The Fantastic Four (1985)(Adventure Soft)(Side B)[cr Blade].dsk" offset="0" sha1="e78a2fae2d7dba872193a82e672fbe19" size="143360" /></dataarea></part></software>
+<software name="Questrona">
+<description>Questron </description>
+<year>1984</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ea972e25" name="Questron (1984)(SSI)(Disk 1 of 3)[a][RDOS].dsk" offset="0" sha1="9d3a60fac3dd7f5b2178d9e7de9847c0" size="143360" /></dataarea></part></software>
+<software name="QuestronRDO">
+<description>Questron </description>
+<year>1984</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="40114ca4" name="Questron (1984)(SSI)(Disk 1 of 3)[RDOS].dsk" offset="0" sha1="c464fa845cbc510416f01fddff69b7a6" size="143360" /></dataarea></part></software>
+<software name="QuestronRDO">
+<description>Questron </description>
+<year>1984</year>
+<publisher>Disk 2 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="841215e5" name="Questron (1984)(SSI)(Disk 2 of 3)[RDOS].dsk" offset="0" sha1="a75a8739804e2970253a6615b8d067a1" size="143360" /></dataarea></part></software>
+<software name="QuestronRDO">
+<description>Questron </description>
+<year>1984</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="09fbf1a3" name="Questron (1984)(SSI)(Disk 3 of 3)[RDOS].dsk" offset="0" sha1="002358159e04c2cb0048efb923b31173" size="143360" /></dataarea></part></software>
+<software name="QuestronRDO">
+<description>Questron II </description>
+<year>1988</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cc3687d7" name="Questron II (1988)(SSI)(Disk 1 of 2 Side A)[RDOS].dsk" offset="0" sha1="1fe8546aef6491bb565f3d80c7df197c" size="143360" /></dataarea></part></software>
+<software name="Questron">
+<description>Questron II </description>
+<year>1988</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="619ed408" name="Questron II (1988)(SSI)(Disk 1 of 2 Side B).dsk" offset="0" sha1="a39472ca84add98bca03fdc0065bf840" size="143360" /></dataarea></part></software>
+<software name="Questron">
+<description>Questron II </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f78db22d" name="Questron II (1988)(SSI)(Disk 2 of 2)(Character).dsk" offset="0" sha1="da8f77b42b49adfa7a083143d54051e8" size="143360" /></dataarea></part></software>
+<software name="Questrona">
+<description>Questron II </description>
+<year>1988</year>
+<publisher>Character</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ff42d332" name="Questron II (1988)(SSI)(Disk 2 of 2)(Character)[a].dsk" offset="0" sha1="0ca2a63d3296c4e1ac9f657d63f40db6" size="143360" /></dataarea></part></software>
+<software name="RactercrB">
+<description>Racter </description>
+<year>1985</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="861faa7d" name="Racter (1985)(Mindscape)[cr Black Bag][PASCAL].dsk" offset="0" sha1="d416fc7d21bf0879df4814f8b7d0400f" size="143360" /></dataarea></part></software>
+<software name="RadioConcrD">
+<description>Radio Control Flight Simulator </description>
+<year>19xx</year>
+<publisher>John Fallend</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0c862d55" name="Radio Control Flight Simulator (19xx)(John Fallend)[cr Disk Jockey].dsk" offset="0" sha1="55f155dd3eb6d0b4ca99bf34903cdb8e" size="143360" /></dataarea></part></software>
+<software name="Radwarri">
+<description>Radwarrior </description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d5d27076" name="Radwarrior (1987)(Epyx).dsk" offset="0" sha1="94ed9553c9e3e36634cfa5dcd2543885" size="143360" /></dataarea></part></software>
+<software name="RaidOver">
+<description>Raid Over Moscow </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cad867b4" name="Raid Over Moscow (1985)(Access).dsk" offset="0" sha1="309de991f370c37dbc32dc4d77113d68" size="143360" /></dataarea></part></software>
+<software name="RaidOvera">
+<description>Raid Over Moscow </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d7886e89" name="Raid Over Moscow (1985)(Access)[a].dsk" offset="0" sha1="e5a48870fec89cd0a87079f18c1f1bfe" size="143360" /></dataarea></part></software>
+<software name="RaidOvercrB">
+<description>Raid Over Moscow </description>
+<year>1985</year>
+<publisher>Access</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6c8277e1" name="Raid Over Moscow (1985)(Access)[cr Bunnymen].dsk" offset="0" sha1="200a2fee9445335feaee10e068fad829" size="143360" /></dataarea></part></software>
+<software name="RailsWes">
+<description>Rails West! </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1cc037da" name="Rails West! (1983)(SSI).dsk" offset="0" sha1="67b596a7cdfa0ab763925803327014b1" size="143360" /></dataarea></part></software>
+<software name="Rampage">
+<description>Rampage </description>
+<year>1988</year>
+<publisher>Monarch Development</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="92baaac9" name="Rampage (1988)(Monarch Development).dsk" offset="0" sha1="e279001f471eeb15290a29b63600462c" size="143360" /></dataarea></part></software>
+<software name="RampagecrB">
+<description>Rampage </description>
+<year>1988</year>
+<publisher>Monarch Development</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2c6f622e" name="Rampage (1988)(Monarch Development)[cr Blade].dsk" offset="0" sha1="3b46334b3527d107a8399d7aa888915b" size="143360" /></dataarea></part></software>
+<software name="RandamncrC">
+<description>Randamn </description>
+<year>1983</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="70953417" name="Randamn (1983)(-)[cr Clean Crack Band].dsk" offset="0" sha1="e5a6265b1a392170ac58eef5012de6b9" size="143360" /></dataarea></part></software>
+<software name="RealmofIcrD">
+<description>Realm of Impossibility </description>
+<year>1986</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e03c6fea" name="Realm of Impossibility (1986)(Electronic Arts)[cr Digital Gang].dsk" offset="0" sha1="9bdd5b52f79406f539d34ef605952f3a" size="143360" /></dataarea></part></software>
+<software name="RealmofIcrD">
+<description>Realm of Impossibility </description>
+<year>1986</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="2ed419ef" name="Realm of Impossibility (1986)(Electronic Arts)[cr Digital Gang][o].dsk" offset="0" sha1="8badad648deae9b083b09c4403d9a6bb" size="143363" /></dataarea></part></software>
+<software name="RebelChaRDO">
+<description>Rebel Charge at Chickamauga </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4118631c" name="Rebel Charge at Chickamauga (1987)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="9c0d2ad782c0f61e278870c2d51b8b35" size="143360" /></dataarea></part></software>
+<software name="RebelChaRDO">
+<description>Rebel Charge at Chickamauga </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1976271" name="Rebel Charge at Chickamauga (1987)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="0b2fb2c594f0a9a0ce65ea6a1cbdc500" size="143360" /></dataarea></part></software>
+<software name="ReforgerRDO">
+<description>Reforger 88 </description>
+<year>1984</year>
+<publisher>Gary Grigsby</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dfceb276" name="Reforger 88 (1984)(Gary Grigsby)[RDOS].dsk" offset="0" sha1="b61718a6009b711cf658a8d6657f3026" size="143360" /></dataarea></part></software>
+<software name="RescueoncrB">
+<description>Rescue on Fractalus </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="20664b94" name="Rescue on Fractalus (1985)(Lucasfilm Games)[cr Black Bag - L.S.D.].dsk" offset="0" sha1="09b6f421b712389c170aa9b7d6bcbefa" size="143360" /></dataarea></part></software>
+<software name="RescueoncrB">
+<description>Rescue on Fractalus </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="449de4a5" name="Rescue on Fractalus (1985)(Lucasfilm Games)[cr Black Bag - L.S.D.][a].dsk" offset="0" sha1="4a6932c11d309afb833f72dc1a404647" size="143360" /></dataarea></part></software>
+<software name="RescueoncrB">
+<description>Rescue on Fractalus </description>
+<year>1985</year>
+<publisher>Lucasfilm Games</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="97dd7f4b" name="Rescue on Fractalus (1985)(Lucasfilm Games)[cr Blade].dsk" offset="0" sha1="0c67c2d5bc7b59ac7a329a3252acea65" size="143360" /></dataarea></part></software>
+<software name="RescueRacrR">
+<description>Rescue Raiders </description>
+<year>1984</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4a0e3ca0" name="Rescue Raiders (1984)(Sir Tech)[cr Racketeers].dsk" offset="0" sha1="c1e79ebea2baa55f36165006d8e0aef8" size="143360" /></dataarea></part></software>
+<software name="RescueRacrR">
+<description>Rescue Raiders </description>
+<year>1984</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="d52fb902" name="Rescue Raiders (1984)(Sir Tech)[cr Racketeers][o].dsk" offset="0" sha1="2df3f79207b3f8632d94c68677752e3b" size="143363" /></dataarea></part></software>
+<software name="RescueRacrR">
+<description>Rescue Raiders </description>
+<year>1984</year>
+<publisher>Sir Tech</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="22ae00bd" name="Rescue Raiders (1984)(Sir Tech)[cr Racketeers][o][a].dsk" offset="0" sha1="05f27a639c5bcd4904328f817e42a3d0" size="143488" /></dataarea></part></software>
+<software name="Returnof">
+<description>Return of Heracles </description>
+<year>1983</year>
+<publisher>Stuart Smith</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="76a3391d" name="Return of Heracles (1983)(Stuart Smith).dsk" offset="0" sha1="422bd8c4abc879a40b37acdab5370d11" size="143360" /></dataarea></part></software>
+<software name="RightAga">
+<description>Right Again </description>
+<year>1984</year>
+<publisher>Ascension Designs</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2961c4cf" name="Right Again (1984)(Ascension Designs).dsk" offset="0" sha1="5dc029daf93214eca35cf90bc74be881" size="143360" /></dataarea></part></software>
+<software name="RingsidecrT">
+<description>Ringside Seat </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7e6e6cda" name="Ringside Seat (1983)(SSI)[cr T. Foley][RDOS].dsk" offset="0" sha1="b8a8090360a7cae758d52f210b39c3d5" size="143360" /></dataarea></part></software>
+<software name="RingsideRDO">
+<description>Ringside Seat </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="877febf2" name="Ringside Seat (1983)(SSI)[RDOS].dsk" offset="0" sha1="86c4aa06325a7f755f7e4e795848e91e" size="143360" /></dataarea></part></software>
+<software name="RoadtoGeRDO">
+<description>Road to Gettysburg, The </description>
+<year>1982</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dad6f52c" name="Road to Gettysburg, The (1982)(SSI)[RDOS].dsk" offset="0" sha1="49fa2982fdd93e2e431c9455e459fff9" size="143360" /></dataarea></part></software>
+<software name="Roadwar2crD">
+<description>Roadwar 2000 </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cec325c5" name="Roadwar 2000 (1986)(SSI)(Side A)[cr Digital Gang][RDOS].dsk" offset="0" sha1="e17b1303e84f59709b59f1ce4656bc1c" size="143360" /></dataarea></part></software>
+<software name="Roadwar2RDO">
+<description>Roadwar 2000 </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="95e5fc48" name="Roadwar 2000 (1986)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="66befc4bae615c8623904385fa06c7bc" size="143360" /></dataarea></part></software>
+<software name="Roadwar2crD">
+<description>Roadwar 2000 </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e422b02e" name="Roadwar 2000 (1986)(SSI)(Side B)[cr Digital Gang][RDOS].dsk" offset="0" sha1="10d836a57b01a42c82d53e74855e861a" size="143360" /></dataarea></part></software>
+<software name="Roadwar2RDO">
+<description>Roadwar 2000 Europa </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d92c0728" name="Roadwar 2000 Europa (1987)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="c8d1e7eaa8e3846be57df272bdffc579" size="143360" /></dataarea></part></software>
+<software name="Roadwar2RDO">
+<description>Roadwar 2000 Europa </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ef82f537" name="Roadwar 2000 Europa (1987)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="095d9ac660c019e8ee526d71377aef7b" size="143360" /></dataarea></part></software>
+<software name="Robotics">
+<description>Robotics </description>
+<year>1986</year>
+<publisher>Andrew Willmott</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7cbfbde3" name="Robotics (1986)(Andrew Willmott).dsk" offset="0" sha1="0ac376182bd0a7d2f2c9d615d9e63822" size="143360" /></dataarea></part></software>
+<software name="RunforItb">
+<description>Run for It </description>
+<year>1984</year>
+<publisher>Optimun Resource</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9cb1df57" name="Run for It (1984)(Optimun Resource)[b].dsk" offset="0" sha1="73307d14d4eb994c661de5f8ecbd8577" size="143360" /></dataarea></part></software>
+<software name="RunforItcrR">
+<description>Run for It </description>
+<year>1984</year>
+<publisher>Optimun Resource</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1d91c47d" name="Run for It (1984)(Optimun Resource)[cr Racketeers].dsk" offset="0" sha1="cd3556edbdbe9cc604443f0f0a8b9d87" size="143360" /></dataarea></part></software>
+<software name="SammyLigcrM">
+<description>Sammy Lightfoot </description>
+<year>1983</year>
+<publisher>Sierra</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3f1c275f" name="Sammy Lightfoot (1983)(Sierra)[cr Mr. Krac-Man].dsk" offset="0" sha1="0b247b5159f3c040fcd40b87147da84c" size="143360" /></dataarea></part></software>
+<software name="SammyLigcrM">
+<description>Sammy Lightfoot </description>
+<year>1983</year>
+<publisher>Sierra</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="31383748" name="Sammy Lightfoot (1983)(Sierra)[cr Mr. Krac-Man][o].dsk" offset="0" sha1="d2bab4633d0827bf4a269cf1cd101892" size="143363" /></dataarea></part></software>
+<software name="SandsofEcrH">
+<description>Sands of Egypt, The </description>
+<year>1982</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8349d020" name="Sands of Egypt, The (1982)(Datasoft)[cr Hi-Res Hijackers - Club 68000].dsk" offset="0" sha1="41d6086df0b41e57b13eeba7a4c5a491" size="143360" /></dataarea></part></software>
+<software name="SantaPar">
+<description>Santa Paravia And Fiumaccio </description>
+<year>1979</year>
+<publisher>Instant</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5940146f" name="Santa Paravia And Fiumaccio (1979)(Instant).dsk" offset="0" sha1="05516a7d6b2cbd883273e5bacbd5f668" size="143360" /></dataarea></part></software>
+<software name="Saracencr">
+<description>Saracen </description>
+<year>1987</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b8c903e4" name="Saracen (1987)(Datasoft)[cr].dsk" offset="0" sha1="11f7b0862d37cf172564401c678f1d99" size="143360" /></dataarea></part></software>
+<software name="SargonIIcrB">
+<description>Sargon III </description>
+<year>1983</year>
+<publisher>Hayden Book</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143363">
+<rom crc="03b2b284" name="Sargon III (1983)(Hayden Book)[cr Buffalo Bill][o].dsk" offset="0" sha1="88f64c26816e3b7421557819b365e8bb" size="143363" /></dataarea></part></software>
+<software name="ScoopcrA">
+<description>Scoop </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fdc8d60e" name="Scoop (1985)(Loriciels)(FR)(Side A)[cr A.B.C.].dsk" offset="0" sha1="a02ffd73bab0f4af42ff9a0c3475588e" size="143360" /></dataarea></part></software>
+<software name="ScoopcrA">
+<description>Scoop </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5fb99d27" name="Scoop (1985)(Loriciels)(FR)(Side B)[cr A.B.C.].dsk" offset="0" sha1="cb7766c259e6fad84b5be3aeed9c1dbe" size="143360" /></dataarea></part></software>
+<software name="Seastalk">
+<description>Seastalker </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8dd2ae59" name="Seastalker (1984)(Infocom).dsk" offset="0" sha1="a28081c694a69b5b821f7bf06164e766" size="143360" /></dataarea></part></software>
+<software name="SeuisShoRDO">
+<description>Seuis Shoot'em Up in Space </description>
+<year>1983</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f489f352" name="Seuis Shoot'em Up in Space (1983)(SSI)[RDOS].dsk" offset="0" sha1="51c30a2ac7394229a8af0bfbcf840b2e" size="143360" /></dataarea></part></software>
+<software name="SevenCitcrA">
+<description>Seven Cities of Gold </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8505c130" name="Seven Cities of Gold (1984)(Electronic Arts)(Disk 1 of 2)[cr Ace].dsk" offset="0" sha1="31fc5e844adae29f4ec75b72e84a7e10" size="143360" /></dataarea></part></software>
+<software name="SevenCitcrC">
+<description>Seven Cities of Gold </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c8c0afa9" name="Seven Cities of Gold (1984)(Electronic Arts)(Disk 1 of 2)[cr Cracking Elite Software].dsk" offset="0" sha1="be3279e3481d14026072247a4ec80a81" size="143360" /></dataarea></part></software>
+<software name="SevenCitcrR">
+<description>Seven Cities of Gold </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a628ebd7" name="Seven Cities of Gold (1984)(Electronic Arts)(Disk 1 of 2)[cr Racketeers].dsk" offset="0" sha1="97c3f58f85f4faffedd65897fb087b42" size="143360" /></dataarea></part></software>
+<software name="SevenCit">
+<description>Seven Cities of Gold </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5770b9e1" name="Seven Cities of Gold (1984)(Electronic Arts)(Disk 2 of 2).dsk" offset="0" sha1="9f4bab2fe02ad518b43a24915cdf96b5" size="143360" /></dataarea></part></software>
+<software name="SevenCitcrC">
+<description>Seven Cities of Gold </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="39306f03" name="Seven Cities of Gold (1984)(Electronic Arts)(Disk 2 of 2)[cr Cracking Elite Software].dsk" offset="0" sha1="3be0409d578f79573c76fea253059009" size="143360" /></dataarea></part></software>
+<software name="ShardofScrC">
+<description>Shard of Spring, The </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="778b2d6d" name="Shard of Spring, The (1986)(SSI)(Disk 1 of 2)[cr Coast to Coast][RDOS].dsk" offset="0" sha1="87d8f500cdffada2dd8f33e5e441eac3" size="143360" /></dataarea></part></software>
+<software name="ShardofSRDO">
+<description>Shard of Spring, The </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2fb89106" name="Shard of Spring, The (1986)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="7aceb9790d1609b15cb4cdd4ce9d12d1" size="143360" /></dataarea></part></software>
+<software name="ShardofS">
+<description>Shard of Spring, The </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fb77ba19" name="Shard of Spring, The (1986)(SSI)(Disk 2 of 2).dsk" offset="0" sha1="53dfa8aa83876117a86355dd19458687" size="143360" /></dataarea></part></software>
+<software name="ShardofScrC">
+<description>Shard of Spring, The </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0511e0ff" name="Shard of Spring, The (1986)(SSI)(Disk 2 of 2)[cr Coast to Coast].dsk" offset="0" sha1="8b3d5d5a304b5a6754cb7481fc6d8ade" size="143360" /></dataarea></part></software>
+<software name="ShattereRDO">
+<description>Shattered Alliance, The </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="636d1780" name="Shattered Alliance, The (1981)(SSI)[RDOS].dsk" offset="0" sha1="4d240f0a8de9c760066c30d9eb2a4427" size="143360" /></dataarea></part></software>
+<software name="Sheilabco">
+<description>Sheila </description>
+<year>1982</year>
+<publisher>H.A.L. Labs</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b04d2043" name="Sheila (1982)(H.A.L. Labs)[b controls].dsk" offset="0" sha1="1a11c81a9731d39e29163648db884421" size="143360" /></dataarea></part></software>
+<software name="SherlockcrG">
+<description>Sherlock Holmes </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="94146014" name="Sherlock Holmes (1985)(Bantam)(Side A)[cr Gadget Master].dsk" offset="0" sha1="79e1545657af7857a0e72e6e390c39e2" size="143360" /></dataarea></part></software>
+<software name="SherlockcrG">
+<description>Sherlock Holmes </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5555b83e" name="Sherlock Holmes (1985)(Bantam)(Side B)[cr Gadget Master].dsk" offset="0" sha1="79f07c94a3c4c8ecf5e6c0d42c4d068a" size="143360" /></dataarea></part></software>
+<software name="Sherwood">
+<description>Sherwood Forest </description>
+<year>1982</year>
+<publisher>Phoenix Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9294c05c" name="Sherwood Forest (1982)(Phoenix Software).dsk" offset="0" sha1="f9aa3a77354afccd0ad2f3a4847c5648" size="143360" /></dataarea></part></software>
+<software name="Sherwoodb">
+<description>Sherwood Forest </description>
+<year>1982</year>
+<publisher>Phoenix Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="71b0e343" name="Sherwood Forest (1982)(Phoenix Software)[b].dsk" offset="0" sha1="08308711b4409d3a19fef72237fd046d" size="143360" /></dataarea></part></software>
+<software name="Sherwoodo">
+<description>Sherwood Forest </description>
+<year>1982</year>
+<publisher>Phoenix Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143616">
+<rom crc="c84a0346" name="Sherwood Forest (1982)(Phoenix Software)[o].dsk" offset="0" sha1="96619cd4090509a124aac6540c586402" size="143616" /></dataarea></part></software>
+<software name="ShilohGrcr6">
+<description>Shiloh Grant's Trial in the West </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="25853eec" name="Shiloh Grant's Trial in the West (1987)(SSI)(Side A)[cr 6502 Crew][RDOS].dsk" offset="0" sha1="82e88803dc59ea5eda63a3adabb5ecb4" size="143360" /></dataarea></part></software>
+<software name="ShilohGrRDO">
+<description>Shiloh Grant's Trial in the West </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="46f1e68c" name="Shiloh Grant's Trial in the West (1987)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="c2a69f340c4d209f37194c71717891a3" size="143360" /></dataarea></part></software>
+<software name="ShilohGrcr6">
+<description>Shiloh Grant's Trial in the West </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="28c4f369" name="Shiloh Grant's Trial in the West (1987)(SSI)(Side B)[cr 6502 Crew][RDOS].dsk" offset="0" sha1="e6e9a011e29c3bd7f8cb9b4d6bf7e4ba" size="143360" /></dataarea></part></software>
+<software name="ShilohGrRDO">
+<description>Shiloh Grant's Trial in the West </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="453ef851" name="Shiloh Grant's Trial in the West (1987)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="7ae5de5164afd09ffacfb6e0838f85a1" size="143360" /></dataarea></part></software>
+<software name="ShortCircrB">
+<description>Short Circuit </description>
+<year>19xx</year>
+<publisher>David Schroeder</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b4e5cd56" name="Short Circuit (19xx)(David Schroeder)[cr Black Market Elite].dsk" offset="0" sha1="40e851034ad7ca521fa62943bf7edccc" size="143360" /></dataarea></part></software>
+<software name="SituatiocrB">
+<description>Situation Critical </description>
+<year>1984</year>
+<publisher>Prism</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="253dafa9" name="Situation Critical (1984)(Prism)[cr Black Bag].dsk" offset="0" sha1="e99364ff7d79aea48680e53c089a2aa2" size="143360" /></dataarea></part></software>
+<software name="SituatiocrB">
+<description>Situation Critical </description>
+<year>1984</year>
+<publisher>Prism</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0b337717" name="Situation Critical (1984)(Prism)[cr Black Bag][a].dsk" offset="0" sha1="f0c39cc7fe7129d2ec8457e990c5e690" size="143360" /></dataarea></part></software>
+<software name="SixgunShRDO">
+<description>Sixgun Shootout </description>
+<year>1985</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83fb0a95" name="Sixgun Shootout (1985)(SSI)[RDOS].dsk" offset="0" sha1="f2ec95b799252635b5ac6a6eb20796cb" size="143360" /></dataarea></part></software>
+<software name="Skyfox">
+<description>Skyfox </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2dcf1d8f" name="Skyfox (1984)(Electronic Arts).dsk" offset="0" sha1="49c7d4cc4db529177ac9f4e6f65eff73" size="143360" /></dataarea></part></software>
+<software name="SkyfoxcrB">
+<description>Skyfox </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4e30d49a" name="Skyfox (1984)(Electronic Arts)[cr Black Bag].dsk" offset="0" sha1="a7faf849d99ee64da9081a0a1d91d965" size="143360" /></dataarea></part></software>
+<software name="SkyfoxcrB">
+<description>Skyfox </description>
+<year>1984</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5a1f3f26" name="Skyfox (1984)(Electronic Arts)[cr Blade].dsk" offset="0" sha1="04aba8d9bcb07cffdec7ca44737baa2b" size="143360" /></dataarea></part></software>
+<software name="SmoothMao">
+<description>Smooth Max </description>
+<year>19xx</year>
+<publisher>Tri-soft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="7bc0f60d" name="Smooth Max (19xx)(Tri-soft)[o].dsk" offset="0" sha1="6dd954b08b44c700cd3d7b3b0e4ec0b9" size="143488" /></dataarea></part></software>
+<software name="SonsofLiRDO">
+<description>Sons of Liberty </description>
+<year>1987</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="af0da5e1" name="Sons of Liberty (1987)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="1cad148460fca370d7837ef04b2873ea" size="143360" /></dataarea></part></software>
+<software name="SonsofLiRDO">
+<description>Sons of Liberty </description>
+<year>1987</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c4ff7217" name="Sons of Liberty (1987)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="bef420c6523cd9a4a253fb71a50b3a7a" size="143360" /></dataarea></part></software>
+<software name="Sorcerer">
+<description>Sorcerer </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f961541c" name="Sorcerer (1984)(Infocom).dsk" offset="0" sha1="bccc29869409fd400267df478a6c4c0d" size="143360" /></dataarea></part></software>
+<software name="SpaceArkcrA">
+<description>Space Ark </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ced5b62" name="Space Ark (1983)(Datamost)(Disk 1 of 2)[cr Apple Bandit].dsk" offset="0" sha1="8e6d77af6f7d81d38cd5bd946543153f" size="143360" /></dataarea></part></software>
+<software name="SpaceArkcrA">
+<description>Space Ark </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1ce3302f" name="Space Ark (1983)(Datamost)(Disk 1 of 2)[cr Apple Bandit][a].dsk" offset="0" sha1="4f11ad52f05132141e760f24da57074c" size="143360" /></dataarea></part></software>
+<software name="SpaceArkcrA">
+<description>Space Ark </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bc053703" name="Space Ark (1983)(Datamost)(Disk 2 of 2)[cr Apple Bandit].dsk" offset="0" sha1="522fdea42000fb0520bbcb48908a5b96" size="143360" /></dataarea></part></software>
+<software name="SpaceArkcrA">
+<description>Space Ark </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a6300b08" name="Space Ark (1983)(Datamost)(Disk 2 of 2)[cr Apple Bandit][a].dsk" offset="0" sha1="7d40add45f4a9992f60b57ada328558e" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 1 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="be824609" name="Space Quest I (1986)(Sierra On-Line)(Disk 1 of 4 Side A)[cr Blade].dsk" offset="0" sha1="de16cfc4a7582085f19c2deb589d6ff4" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 1 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5206e902" name="Space Quest I (1986)(Sierra On-Line)(Disk 1 of 4 Side B)[cr Blade].dsk" offset="0" sha1="464fcd031685c301213ba9613d16e049" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 2 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="261228e9" name="Space Quest I (1986)(Sierra On-Line)(Disk 2 of 4 Side A)[cr Blade].dsk" offset="0" sha1="da5c335bd509082147afcee424d131e5" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 2 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22fdaa64" name="Space Quest I (1986)(Sierra On-Line)(Disk 2 of 4 Side B)[cr Blade].dsk" offset="0" sha1="ed0dec1b4d80895f94b75ed71f26f851" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 3 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2ac6b032" name="Space Quest I (1986)(Sierra On-Line)(Disk 3 of 4 Side A)[cr Blade].dsk" offset="0" sha1="68ed5fccb614293886bd3c7bbb129685" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 3 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="51bb0060" name="Space Quest I (1986)(Sierra On-Line)(Disk 3 of 4 Side B)[cr Blade][DOS].dsk" offset="0" sha1="e54696c786b12ea3e303846a1ec6245f" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 4 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3f34466f" name="Space Quest I (1986)(Sierra On-Line)(Disk 4 of 4 Side A)[cr Blade].dsk" offset="0" sha1="65deea95c6bf2af1fc1bb4a0da07bf05" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest I </description>
+<year>1986</year>
+<publisher>Disk 4 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ed725852" name="Space Quest I (1986)(Sierra On-Line)(Disk 4 of 4 Side B)[cr Blade].dsk" offset="0" sha1="e85d6515cd731391f8ca43f822d70312" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 1 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="29fa5696" name="Space Quest II (1987)(Sierra On-Line)(Disk 1 of 4 Side A)[cr Blade][b].dsk" offset="0" sha1="3cb8b626285cee78131c3baeced4541f" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 1 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="521031df" name="Space Quest II (1987)(Sierra On-Line)(Disk 1 of 4 Side B)[cr Blade][b].dsk" offset="0" sha1="1deb1497ca803cf101b840bb57000be7" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 2 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e3732c96" name="Space Quest II (1987)(Sierra On-Line)(Disk 2 of 4 Side A)[cr Blade][b].dsk" offset="0" sha1="a3a4b06ce668d1563361907e1a0725c2" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 2 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="fdc3397b" name="Space Quest II (1987)(Sierra On-Line)(Disk 2 of 4 Side B)[cr Blade][b].dsk" offset="0" sha1="3cf319eb895c9ded0d75617eadc405a5" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 3 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f73ec7fa" name="Space Quest II (1987)(Sierra On-Line)(Disk 3 of 4 Side A)[cr Blade][b].dsk" offset="0" sha1="c3d8c78d4445faa13b1d09c0536a46c6" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 3 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c6c54b24" name="Space Quest II (1987)(Sierra On-Line)(Disk 3 of 4 Side B)[cr Blade][b].dsk" offset="0" sha1="ad254fab47aacc471a2f0b85680690e6" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 4 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="083de568" name="Space Quest II (1987)(Sierra On-Line)(Disk 4 of 4 Side A)[cr Blade][b][DOS].dsk" offset="0" sha1="1e88a6c6c19758074186d721ce97fbf4" size="143360" /></dataarea></part></software>
+<software name="SpaceQuecrB">
+<description>Space Quest II </description>
+<year>1987</year>
+<publisher>Disk 4 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2c0b58fe" name="Space Quest II (1987)(Sierra On-Line)(Disk 4 of 4 Side B)[cr Blade][b].dsk" offset="0" sha1="e889d23a14463f9126f9dde71d76a635" size="143360" /></dataarea></part></software>
+<software name="SpaceShucrP">
+<description>Space Shuttle - A Jouney into Space </description>
+<year>1985</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d802ddb1" name="Space Shuttle - A Jouney into Space (1985)(Activision)[cr PPG].dsk" offset="0" sha1="ef18963a672b320627148c7c137747b5" size="143360" /></dataarea></part></software>
+<software name="SpareChacrM">
+<description>Spare Change </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="43dbfdc8" name="Spare Change (1983)(Broderbund)[cr Midwest Pirates Guild].dsk" offset="0" sha1="c0dd0c4390de706afc0a1e2e48e181af" size="143360" /></dataarea></part></software>
+<software name="Spectrecr">
+<description>Spectre </description>
+<year>1982</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1f7f720f" name="Spectre (1982)(Datamost)[cr].dsk" offset="0" sha1="ba2f9972297448e8c064e68bab82b26e" size="143360" /></dataarea></part></software>
+<software name="Spellbre">
+<description>Spellbreaker </description>
+<year>1985</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1318d43d" name="Spellbreaker (1985)(Infocom).dsk" offset="0" sha1="0f559022d5d30e6c70fd5d4be0505a6d" size="143360" /></dataarea></part></software>
+<software name="SpellbrecrD">
+<description>Spellbreaker </description>
+<year>1985</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="22cc1f66" name="Spellbreaker (1985)(Infocom)[cr Digital Gang].dsk" offset="0" sha1="2a53fc215bffa809f5813d45a07a3202" size="143360" /></dataarea></part></software>
+<software name="SpiderbocrB">
+<description>Spiderbot </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eda67b35" name="Spiderbot (1988)(Epyx)[cr Blade].dsk" offset="0" sha1="8ccae1e00773a775062d7b5328a72e70" size="143360" /></dataarea></part></software>
+<software name="SpiderbocrU">
+<description>Spiderbot </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f3455986" name="Spiderbot (1988)(Epyx)[cr USAlliance].dsk" offset="0" sha1="b0f361148d5578503efe5b5dccd8aeca" size="143360" /></dataarea></part></software>
+<software name="SportsJu">
+<description>Sports Judge's Thoroughbred Handicapping System, The </description>
+<year>1984</year>
+<publisher>Pds Sports</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e733d14e" name="Sports Judge's Thoroughbred Handicapping System, The (1984)(Pds Sports).dsk" offset="0" sha1="e045f4ffca647b7db976e81a2afda25b" size="143360" /></dataarea></part></software>
+<software name="SputnikA">
+<description>Sputnik Attack </description>
+<year>19xx</year>
+<publisher>Leo Law</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2dcdf40c" name="Sputnik Attack (19xx)(Leo Law).dsk" offset="0" sha1="3612a382d245c20beca493b20332de84" size="143360" /></dataarea></part></software>
+<software name="SputnikAa">
+<description>Sputnik Attack </description>
+<year>19xx</year>
+<publisher>Leo Law</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4a4beeaf" name="Sputnik Attack (19xx)(Leo Law)[a].dsk" offset="0" sha1="4fc02b32abaa93341bf82d839a25e41f" size="143360" /></dataarea></part></software>
+<software name="SpyVsSpy">
+<description>Spy Vs Spy </description>
+<year>1984</year>
+<publisher>First Star Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1578610e" name="Spy Vs Spy (1984)(First Star Software).dsk" offset="0" sha1="cf856d761d2a827e38b106ada792c109" size="143360" /></dataarea></part></software>
+<software name="SpyVsSpycrH">
+<description>Spy Vs Spy </description>
+<year>1984</year>
+<publisher>First Star Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a7bde2f0" name="Spy Vs Spy (1984)(First Star Software)[cr High Society].dsk" offset="0" sha1="c74b364cb33fd57a1771166f1d9c3be6" size="143360" /></dataarea></part></software>
+<software name="SpyVsSpycrH">
+<description>Spy Vs Spy </description>
+<year>1984</year>
+<publisher>First Star Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6c9ed036" name="Spy Vs Spy (1984)(First Star Software)[cr High Society][a].dsk" offset="0" sha1="0172abe84fdb57ad6e4eb0ebd1e97018" size="143360" /></dataarea></part></software>
+<software name="SpyVsSpy">
+<description>Spy Vs Spy 3 - Artic Antics </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2acf8891" name="Spy Vs Spy 3 - Artic Antics (1988)(Epyx).dsk" offset="0" sha1="987229016b13fb5a9738a58da10b087b" size="143360" /></dataarea></part></software>
+<software name="SpyVsSpycrH">
+<description>Spy Vs Spy 3 - Artic Antics </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="152db2dc" name="Spy Vs Spy 3 - Artic Antics (1988)(Epyx)[cr Highlanders Team].dsk" offset="0" sha1="ef87fdfb79c7263fc418cd512ac4e073" size="143360" /></dataarea></part></software>
+<software name="StarCrys">
+<description>Star Crystal </description>
+<year>1985</year>
+<publisher>Disk 1 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e81228d9" name="Star Crystal (1985)(Ba'rac Limited)(Disk 1 of 3).dsk" offset="0" sha1="72997b1f5a1b441d64874ab05b495c5f" size="143360" /></dataarea></part></software>
+<software name="StarCrysdat">
+<description>Star Crystal </description>
+<year>1985</year>
+<publisher>Disk 2 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ad5afd1b" name="Star Crystal (1985)(Ba'rac Limited)(Disk 2 of 3)[data A].dsk" offset="0" sha1="1848c12eb876b23a6e043fb76b5a89f3" size="143360" /></dataarea></part></software>
+<software name="StarCrysdat">
+<description>Star Crystal </description>
+<year>1985</year>
+<publisher>Disk 3 of 3</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6e9410d3" name="Star Crystal (1985)(Ba'rac Limited)(Disk 3 of 3)[data B].dsk" offset="0" sha1="5fac3a9f97007594f99eb5c84eb7c74d" size="143360" /></dataarea></part></software>
+<software name="StarRankcrK">
+<description>Star Rank Boxing 2 v1.0 </description>
+<year>1988</year>
+<publisher>Gamestar</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="799ba5b8" name="Star Rank Boxing 2 v1.0 (1988)(Gamestar)[cr Keith Wong - Vincent].dsk" offset="0" sha1="ddb34fa6d0575202a5396c93a4bb040a" size="143360" /></dataarea></part></software>
+<software name="StarTrekcrF">
+<description>Star Trek - Promethean Prophecy </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="435603da" name="Star Trek - Promethean Prophecy (1986)(Simon &amp; Schuster)(Side A)[cr First Class].dsk" offset="0" sha1="0aaf3c3474dc5f52ab1b5de1c15498a8" size="143360" /></dataarea></part></software>
+<software name="StarTrekcrF">
+<description>Star Trek - Promethean Prophecy </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ae4cc42" name="Star Trek - Promethean Prophecy (1986)(Simon &amp; Schuster)(Side B)[cr First Class].dsk" offset="0" sha1="507c475b2520e22d9a67d4ddb1551217" size="143360" /></dataarea></part></software>
+<software name="Starcros">
+<description>Starcross </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c0e4f5e0" name="Starcross (1982)(Infocom).dsk" offset="0" sha1="0864ac7730e76ade622b2f010a59ddb1" size="143360" /></dataarea></part></software>
+<software name="Starcrosa">
+<description>Starcross </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8ddb5741" name="Starcross (1982)(Infocom)[a].dsk" offset="0" sha1="cd0a2c2e6102a043185fad2ca9fa0b55" size="143360" /></dataarea></part></software>
+<software name="Starquesb">
+<description>Starquest - Rescue at Rigel </description>
+<year>1980</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="49a8eb89" name="Starquest - Rescue at Rigel (1980)(Epyx)[b][no boot].dsk" offset="0" sha1="e09a5ddc54152d5fa4d674db09dfaf39" size="143360" /></dataarea></part></software>
+<software name="StationF">
+<description>Station Five </description>
+<year>1984</year>
+<publisher>Micro Fun</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="00cd9370" name="Station Five (1984)(Micro Fun).dsk" offset="0" sha1="ebcbd25a1d70022f5402638642cc536b" size="143360" /></dataarea></part></software>
+<software name="StephenKcrS">
+<description>Stephen King - The Mist </description>
+<year>1985</year>
+<publisher>Mindscape</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f55774d4" name="Stephen King - The Mist (1985)(Mindscape)[cr Sean Johnson][PASCAL].dsk" offset="0" sha1="015e3c3258675c40104116105ef0c0e4" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 1 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2706a860" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 1 of 6).dsk" offset="0" sha1="f178efd281b9e21494bce856cb15278d" size="143360" /></dataarea></part></software>
+<software name="SteveKeea">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 1 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="74f55f8b" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 1 of 6)[a].dsk" offset="0" sha1="71c911341c7b27652616316365220078" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 2 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="adb5af85" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 2 of 6).dsk" offset="0" sha1="259cd527c2abe8ec2e65addb9ef84ed2" size="143360" /></dataarea></part></software>
+<software name="SteveKeea">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 2 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="caa8162e" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 2 of 6)[a].dsk" offset="0" sha1="d300889c0239d9ff21c5b0d2528e64cc" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 3 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ef305870" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 3 of 6).dsk" offset="0" sha1="3838a471853e7d746eed3afef7bc008a" size="143360" /></dataarea></part></software>
+<software name="SteveKeea">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 3 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2e11d68b" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 3 of 6)[a].dsk" offset="0" sha1="b75e719aebf69b745d7bd441a29bcd78" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 4 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="baf785a7" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 4 of 6).dsk" offset="0" sha1="12a2445bf6ffc9785489aa3bbdc929f3" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 5 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="54b1f03a" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 5 of 6).dsk" offset="0" sha1="edac9b0e57b38bef07b31c436f066ee5" size="143360" /></dataarea></part></software>
+<software name="SteveKee">
+<description>Steve Keene! Private Spy </description>
+<year>1987</year>
+<publisher>Disk 6 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="adf9de7f" name="Steve Keene! Private Spy (1987)(Accolade)(Disk 6 of 6).dsk" offset="0" sha1="cc69d7ea5f25fff4766b7c37368b0d42" size="143360" /></dataarea></part></software>
+<software name="StreetSpcrB">
+<description>Street Sports Baseball </description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e43c0187" name="Street Sports Baseball (1987)(Epyx)[cr Blade].dsk" offset="0" sha1="8e95b189cc09e1e85e33b02e5e4ff7d6" size="143360" /></dataarea></part></software>
+<software name="StreetSpcrD">
+<description>Street Sports Baseball </description>
+<year>1987</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f507ffa6" name="Street Sports Baseball (1987)(Epyx)[cr Digital Gang].dsk" offset="0" sha1="f8f2cce047c30fc22456db2019e0c287" size="143360" /></dataarea></part></software>
+<software name="StreetSp">
+<description>Street Sports Basketball </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bd37feeb" name="Street Sports Basketball (1987)(Epyx)(Side A).dsk" offset="0" sha1="98f7a7292a357d562e6ec9217c86516a" size="143360" /></dataarea></part></software>
+<software name="StreetSpcrB">
+<description>Street Sports Basketball </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7ec0a730" name="Street Sports Basketball (1987)(Epyx)(Side A)[cr Blade].dsk" offset="0" sha1="b93602e545110faed6c270a9ee8557d1" size="143360" /></dataarea></part></software>
+<software name="StreetSp">
+<description>Street Sports Basketball </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83a9bffa" name="Street Sports Basketball (1987)(Epyx)(Side B).dsk" offset="0" sha1="b3bdcd4aa584b97c9e02419aa282c32e" size="143360" /></dataarea></part></software>
+<software name="StreetSpcrB">
+<description>Street Sports Basketball </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="538f3ecb" name="Street Sports Basketball (1987)(Epyx)(Side B)[cr Blade].dsk" offset="0" sha1="d6641086565ffc902e5f76309420f35e" size="143360" /></dataarea></part></software>
+<software name="StreetSp">
+<description>Street Sports Football </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bda9c966" name="Street Sports Football (1988)(Epyx)(Side A).dsk" offset="0" sha1="ec8005d5b50ba410c8cc0ea0d2e393d5" size="143360" /></dataarea></part></software>
+<software name="StreetSp">
+<description>Street Sports Football </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0de0863b" name="Street Sports Football (1988)(Epyx)(Side B).dsk" offset="0" sha1="8f1fe0e45c387e8b782a2906825deb3e" size="143360" /></dataarea></part></software>
+<software name="StreetSp">
+<description>Street Sports Soccer </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5ce205ea" name="Street Sports Soccer (1988)(Epyx).dsk" offset="0" sha1="4ff855d04f989fdd331b4328405e71f4" size="143360" /></dataarea></part></software>
+<software name="StreetSpcrB">
+<description>Street Sports Soccer </description>
+<year>1988</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ada7a649" name="Street Sports Soccer (1988)(Epyx)[cr Blade][b].dsk" offset="0" sha1="52fcc0276b28ab1a8b98965d6f88e9ec" size="143360" /></dataarea></part></software>
+<software name="StrikeFlcrB">
+<description>Strike Fleet </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="725fd78d" name="Strike Fleet (1987)(Electronic Arts - Lucasfilm Games)(Side A)[cr Blade].dsk" offset="0" sha1="db93399e05257fa19d1b7b9ae96a5651" size="143360" /></dataarea></part></software>
+<software name="StrikeFlcrB">
+<description>Strike Fleet </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7a32559f" name="Strike Fleet (1987)(Electronic Arts - Lucasfilm Games)(Side B)[cr Blade].dsk" offset="0" sha1="b56d334ebb3a6acc1229cde7659db188" size="143360" /></dataarea></part></software>
+<software name="StripBlacrM">
+<description>Strip Blackjack </description>
+<year>1983</year>
+<publisher>Sansoft Plus</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cd13f1e6" name="Strip Blackjack (1983)(Sansoft Plus)[cr Mr. Krac-Man].dsk" offset="0" sha1="80a24839236882890759d99974fdb01d" size="143360" /></dataarea></part></software>
+<software name="SummerGa">
+<description>Summer Games </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9872dcb8" name="Summer Games (1984)(Epyx)(Side A).dsk" offset="0" sha1="588f61d11bd7ea39606397e47a4f8a00" size="143360" /></dataarea></part></software>
+<software name="SummerGa">
+<description>Summer Games </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5dcb73fc" name="Summer Games (1984)(Epyx)(Side B).dsk" offset="0" sha1="1d1993daad4f8c0823c7e6f613d52343" size="143360" /></dataarea></part></software>
+<software name="SummerGacrB">
+<description>Summer Games II </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6801a8d5" name="Summer Games II (1985)(Epyx)(Side A)[cr Black Bag].dsk" offset="0" sha1="778372e82bd4c0fccc7eb9a576a36013" size="143360" /></dataarea></part></software>
+<software name="SummerGacrB">
+<description>Summer Games II </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="101b18c3" name="Summer Games II (1985)(Epyx)(Side A)[cr Black Bag][a].dsk" offset="0" sha1="d6b193c8543d7d992afcdc0ffcb3378e" size="143360" /></dataarea></part></software>
+<software name="SummerGacrB">
+<description>Summer Games II </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1dc1d57a" name="Summer Games II (1985)(Epyx)(Side B)[cr Black Bag].dsk" offset="0" sha1="3aa40c33a44049da0b0eb26790db6249" size="143360" /></dataarea></part></software>
+<software name="SundogFr">
+<description>Sundog Frozen Legacy v1.10 </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4e49b49e" name="Sundog Frozen Legacy v1.10 (1984)(FTL)(Side A).dsk" offset="0" sha1="1d0a4ba70ca6a24dcee248300595a821" size="143360" /></dataarea></part></software>
+<software name="SundogFr">
+<description>Sundog Frozen Legacy v1.10 </description>
+<year>1984</year>
+<publisher>Utility</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0801cfac" name="Sundog Frozen Legacy v1.10 (1984)(FTL)(Side B)(Utility).dsk" offset="0" sha1="49a827fc496864a8a3161d3ce5373273" size="143360" /></dataarea></part></software>
+<software name="SundogFrcrN">
+<description>Sundog Frozen Legacy v2.0 </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="34e0a7af" name="Sundog Frozen Legacy v2.0 (1984)(FTL)(Disk 1 of 2)[cr Nut Cracker].dsk" offset="0" sha1="1b6c911d97b91a078c3e4ac5a18cc72b" size="143360" /></dataarea></part></software>
+<software name="SundogFrcrN">
+<description>Sundog Frozen Legacy v2.0 </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6dce9e24" name="Sundog Frozen Legacy v2.0 (1984)(FTL)(Disk 2 of 2)[cr Nut Cracker].dsk" offset="0" sha1="1fe7dfeaaa18fb81f96f805cd272064e" size="143360" /></dataarea></part></software>
+<software name="SuperBoucrP">
+<description>Super Boulderdash </description>
+<year>1986</year>
+<publisher>Electronic Arts</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3c2146ea" name="Super Boulderdash (1986)(Electronic Arts)[cr Piracy Zone Software].dsk" offset="0" sha1="1737dd102fd67908e9a28e124d8686f2" size="143360" /></dataarea></part></software>
+<software name="SuperTaxcrZ">
+<description>Super Taxman 2 </description>
+<year>1981</year>
+<publisher>H.A.L. Labs</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ac3f7bec" name="Super Taxman 2 (1981)(H.A.L. Labs)[cr Zero Page].dsk" offset="0" sha1="33e6eff86624a785889ac19d7474d72c" size="143360" /></dataarea></part></software>
+<software name="SuperTaxcr">
+<description>Super Taxman 2 </description>
+<year>1981</year>
+<publisher>H.A.L. Labs</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a8174fd5" name="Super Taxman 2 (1981)(H.A.L. Labs)[cr].dsk" offset="0" sha1="d9cb2abda365ce1ee7d553f68b7e0c87" size="143360" /></dataarea></part></software>
+<software name="SuperZaxcrM">
+<description>Super Zaxxon </description>
+<year>1983</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8f844cdf" name="Super Zaxxon (1983)(Datasoft)[cr Midwest Pirates Guild].dsk" offset="0" sha1="375a5e58c757704c70d8f83e9b86f53a" size="143360" /></dataarea></part></software>
+<software name="SuperZaxcrM">
+<description>Super Zaxxon </description>
+<year>1983</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2f10364d" name="Super Zaxxon (1983)(Datasoft)[cr Mr. Krac-Man].dsk" offset="0" sha1="232143e7fb3ef24442636d7ec6d4741d" size="143360" /></dataarea></part></software>
+<software name="Suspect-">
+<description>Suspect - An Interactive Mystery </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0e42610c" name="Suspect - An Interactive Mystery (1984)(Infocom).dsk" offset="0" sha1="9bbe6ba134ec0fc6d295042cbeef6532" size="143360" /></dataarea></part></software>
+<software name="Suspect-crW">
+<description>Suspect - An Interactive Mystery </description>
+<year>1984</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="27107d5e" name="Suspect - An Interactive Mystery (1984)(Infocom)[cr Wareforce].dsk" offset="0" sha1="e8549e69f0fb5fca431cc6a5c28a2ac5" size="143360" /></dataarea></part></software>
+<software name="Suspende">
+<description>Suspended </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="dd6813fa" name="Suspended (1983)(Infocom).dsk" offset="0" sha1="882ba562766445c5800e6eff871a3c5d" size="143360" /></dataarea></part></software>
+<software name="Suspende40-">
+<description>Suspended </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="05930dea" name="Suspended (1983)(Infocom)[40-column version].dsk" offset="0" sha1="35f529d63bc088206fa7dfddba427f2a" size="143360" /></dataarea></part></software>
+<software name="Suspendea">
+<description>Suspended </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f777ee19" name="Suspended (1983)(Infocom)[a][40-column version].dsk" offset="0" sha1="06d7aef6b16de31652fd6aae1e7f6cf4" size="143360" /></dataarea></part></software>
+<software name="Swashbucb">
+<description>Swashbuckler </description>
+<year>1982</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="52657e31" name="Swashbuckler (1982)(Datamost)[b].dsk" offset="0" sha1="97e8ec9afb310b4742e3ab81992df860" size="143360" /></dataarea></part></software>
+<software name="SwissFamcrL">
+<description>Swiss Family Robinson </description>
+<year>1984</year>
+<publisher>Telarium</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e2036708" name="Swiss Family Robinson (1984)(Telarium)[cr L.S.D. - S.E.N.D.].dsk" offset="0" sha1="3a8467a5924e4dfda0de4a1d728a49d5" size="143360" /></dataarea></part></software>
+<software name="SwissFamcrL">
+<description>Swiss Family Robinson </description>
+<year>1984</year>
+<publisher>Telarium</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="119a7966" name="Swiss Family Robinson (1984)(Telarium)[cr L.S.D. - S.E.N.D.][a].dsk" offset="0" sha1="78a14f0b598570eaa5c23ed8556617bc" size="143360" /></dataarea></part></software>
+<software name="T-Rex-ThcrB">
+<description>T-Rex - The Dinosaur Survival Adventure </description>
+<year>1984</year>
+<publisher>Keron</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="62dd384e" name="T-Rex - The Dinosaur Survival Adventure (1984)(Keron)[cr Blade].dsk" offset="0" sha1="d278734ce52cf93fdd184c0c55268e5d" size="143360" /></dataarea></part></software>
+<software name="T-Rex-ThcrL">
+<description>T-Rex - The Dinosaur Survival Adventure </description>
+<year>1984</year>
+<publisher>Keron</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="646cabbc" name="T-Rex - The Dinosaur Survival Adventure (1984)(Keron)[cr L.S.D. - S.E.N.D.].dsk" offset="0" sha1="fc933d939905c3a54fa836658da9a434" size="143360" /></dataarea></part></software>
+<software name="Talon">
+<description>Talon </description>
+<year>1983</year>
+<publisher>Broderbund</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="af31ade9" name="Talon (1983)(Broderbund).dsk" offset="0" sha1="1c0f28a582a95daf90ee21a561086e4e" size="143360" /></dataarea></part></software>
+<software name="TechnoCo">
+<description>Techno Cop </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a7417f80" name="Techno Cop (1988)(Gray Matter)(Side A).dsk" offset="0" sha1="60a5f0e4b46b3bec50c05f1105521a6a" size="143360" /></dataarea></part></software>
+<software name="TechnoCocrB">
+<description>Techno Cop </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="82529c0d" name="Techno Cop (1988)(Gray Matter)(Side A)[cr Blade].dsk" offset="0" sha1="d7658012603ee4567298317009b0ddbc" size="143360" /></dataarea></part></software>
+<software name="TechnoCo">
+<description>Techno Cop </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="492a9c7f" name="Techno Cop (1988)(Gray Matter)(Side B).dsk" offset="0" sha1="48d3e27c8b2b1160cfcd4ee43d888664" size="143360" /></dataarea></part></software>
+<software name="TechnoCocrB">
+<description>Techno Cop </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="72768b2f" name="Techno Cop (1988)(Gray Matter)(Side B)[cr Blade].dsk" offset="0" sha1="28ff036cdbd5770f974bd5aff7aea304" size="143360" /></dataarea></part></software>
+<software name="TempleofcrD">
+<description>Temple of Apshai Trilogy </description>
+<year>1985</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e9c31fec" name="Temple of Apshai Trilogy (1985)(Epyx)[cr Digital Gang].dsk" offset="0" sha1="20c47853846741d9542b60247c0b3071" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrB">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9419fc42" name="Test Drive (1988)(Accolade)(Side A)[cr Blade].dsk" offset="0" sha1="11963f177cbfb4b549f3f3119db7ac53" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrH">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6263b664" name="Test Drive (1988)(Accolade)(Side A)[cr Highlanders Team][f].dsk" offset="0" sha1="e9afab06d57e9c62a3c5bf5798c177c1" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrU">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="afb58d2c" name="Test Drive (1988)(Accolade)(Side A)[cr USAlliance].dsk" offset="0" sha1="a3a9cf4747d78f5fac18e66cb8ca6c4c" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrB">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ebc861e2" name="Test Drive (1988)(Accolade)(Side B)[cr Blade].dsk" offset="0" sha1="bd42eebc9498d5429032e0bebf3323ee" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrH">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9881e89c" name="Test Drive (1988)(Accolade)(Side B)[cr Highlanders Team][f].dsk" offset="0" sha1="e8e0c90acdf6624c6371beec44d74692" size="143360" /></dataarea></part></software>
+<software name="TestDrivcrU">
+<description>Test Drive </description>
+<year>1988</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="df196147" name="Test Drive (1988)(Accolade)(Side B)[cr USAlliance].dsk" offset="0" sha1="eb52cc3828dd2a3c5cd47e5153736a41" size="143360" /></dataarea></part></software>
+<software name="Tetris2crB">
+<description>Tetris 2 </description>
+<year>19xx</year>
+<publisher>Jockersoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c9256efa" name="Tetris 2 (19xx)(Jockersoft)[cr Brain Trust][a][reprogrammed].dsk" offset="0" sha1="00adabca2d00b74c6bda840d53b5ae6f" size="143360" /></dataarea></part></software>
+<software name="Tetris2crB">
+<description>Tetris 2 </description>
+<year>19xx</year>
+<publisher>Jockersoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0e9eca1c" name="Tetris 2 (19xx)(Jockersoft)[cr Brain Trust][reprogrammed].dsk" offset="0" sha1="aa5834c655f3967b931aa6e7e637de0b" size="143360" /></dataarea></part></software>
+<software name="Threshol">
+<description>Threshold </description>
+<year>1981</year>
+<publisher>On-Line Systems</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1093aaed" name="Threshold (1981)(On-Line Systems).dsk" offset="0" sha1="bbf2be28e300af71f91218f3743dadb1" size="143360" /></dataarea></part></software>
+<software name="TigersinRDO">
+<description>Tigers in the Snow </description>
+<year>1981</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4edb44e7" name="Tigers in the Snow (1981)(SSI)[RDOS].dsk" offset="0" sha1="12c0306932e3145d2b2e758e1f85301f" size="143360" /></dataarea></part></software>
+<software name="TopFuelEcrB">
+<description>Top Fuel Eliminator </description>
+<year>1987</year>
+<publisher>Activision</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9381aedc" name="Top Fuel Eliminator (1987)(Activision)[cr Blade][b].dsk" offset="0" sha1="98123e96222623af3d19a6b7016e1861" size="143360" /></dataarea></part></software>
+<software name="TracerSacrR">
+<description>Tracer Sanction, The </description>
+<year>1984</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d7b456ec" name="Tracer Sanction, The (1984)(Activision)(Side A)[cr Racketeers].dsk" offset="0" sha1="eac4323ce4ef9978b74221d1042d71a0" size="143360" /></dataarea></part></software>
+<software name="TracerSacrR">
+<description>Tracer Sanction, The </description>
+<year>1984</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eb43d4c5" name="Tracer Sanction, The (1984)(Activision)(Side B)[cr Racketeers].dsk" offset="0" sha1="16049e4d9933dfc80723dfec8b51a2c6" size="143360" /></dataarea></part></software>
+<software name="TrinitycrD">
+<description>Trinity </description>
+<year>1986</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="440f97ed" name="Trinity (1986)(Infocom)(Disk 1 of 2)[cr Digital Gang].dsk" offset="0" sha1="098525eda8c57618016aa9c101185ef3" size="143360" /></dataarea></part></software>
+<software name="TrinitycrD">
+<description>Trinity </description>
+<year>1986</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="77bf2478" name="Trinity (1986)(Infocom)(Disk 2 of 2)[cr Digital Gang].dsk" offset="0" sha1="6619a2088cded97240b354f39801da98" size="143360" /></dataarea></part></software>
+<software name="Typhoonoa">
+<description>Typhoon of Steel - Asia </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="20fb47fa" name="Typhoon of Steel - Asia (1988)(SSI)[a][RDOS].dsk" offset="0" sha1="12452ed6baedb95d746c7d37e6ffa0f7" size="143360" /></dataarea></part></software>
+<software name="TyphoonoRDO">
+<description>Typhoon of Steel - Asia </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d97ab979" name="Typhoon of Steel - Asia (1988)(SSI)[RDOS].dsk" offset="0" sha1="ec5fa64f6d91ab53aa2c79c3e8c7178c" size="143360" /></dataarea></part></software>
+<software name="Typhoonoa">
+<description>Typhoon of Steel - Europe </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f5c919c1" name="Typhoon of Steel - Europe (1988)(SSI)[a][RDOS].dsk" offset="0" sha1="6fd5006d52b22646f83ec3ef6f0b304b" size="143360" /></dataarea></part></software>
+<software name="TyphoonoRDO">
+<description>Typhoon of Steel - Europe </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0c48e742" name="Typhoon of Steel - Europe (1988)(SSI)[RDOS].dsk" offset="0" sha1="1199031b30855ee3e328fe352b07770a" size="143360" /></dataarea></part></software>
+<software name="Typhoonoa">
+<description>Typhoon of Steel - Pacific </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4a5b5349" name="Typhoon of Steel - Pacific (1988)(SSI)[a][RDOS].dsk" offset="0" sha1="8a6c20308c70897c021fcda0029b0db5" size="143360" /></dataarea></part></software>
+<software name="TyphoonoRDO">
+<description>Typhoon of Steel - Pacific </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b3daadca" name="Typhoon of Steel - Pacific (1988)(SSI)[RDOS].dsk" offset="0" sha1="fc07ee8167ff36883d9f6de0c5df5afa" size="143360" /></dataarea></part></software>
+<software name="Typhoono">
+<description>Typhoon of Steel Scenery </description>
+<year>1988</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e9f3eea3" name="Typhoon of Steel Scenery (1988)(SSI).dsk" offset="0" sha1="591e79af6a61e310b77b550da6cb7d04" size="143360" /></dataarea></part></software>
+<software name="U.S.A.A.a">
+<description>U.S.A.A.F. </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="08f84259" name="U.S.A.A.F. (1985)(SSI)(Side A)[a][RDOS].dsk" offset="0" sha1="05c57bbbe19e43207ba39845c8c11ed9" size="143360" /></dataarea></part></software>
+<software name="U.S.A.A.RDO">
+<description>U.S.A.A.F. </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="242d1677" name="U.S.A.A.F. (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="072d534776be98f072abf4ff05241120" size="143360" /></dataarea></part></software>
+<software name="U.S.A.A.RDO">
+<description>U.S.A.A.F. </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="203d51af" name="U.S.A.A.F. (1985)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="250e5ccc996631a626f641a93e562833" size="143360" /></dataarea></part></software>
+<software name="U.S.A.A.RDO">
+<description>U.S.A.A.F. - Alternate 1 </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="77d83757" name="U.S.A.A.F. - Alternate 1 (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="95bffbb1f38e6a281ac1a4f2366378a4" size="143360" /></dataarea></part></software>
+<software name="U.S.A.A.RDO">
+<description>U.S.A.A.F. - Alternate 2 </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="568e12e2" name="U.S.A.A.F. - Alternate 2 (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="177eddaab7f04b8799eb43b847948a90" size="143360" /></dataarea></part></software>
+<software name="UltimaII">
+<description>Ultima II - Revenge of the Enchantress </description>
+<year>1983</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="91f9f927" name="Ultima II - Revenge of the Enchantress (1983)(On-Line Systems)(Disk 1 of 4).dsk" offset="0" sha1="291a52352de2f6346e3865f211d3b019" size="143360" /></dataarea></part></software>
+<software name="UltimaIInob">
+<description>Ultima II - Revenge of the Enchantress </description>
+<year>1983</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="98151406" name="Ultima II - Revenge of the Enchantress (1983)(On-Line Systems)(Disk 1 of 4)[no boot].dsk" offset="0" sha1="5fbed9165147c58e97d8dabb1da3d265" size="143360" /></dataarea></part></software>
+<software name="UltimaII">
+<description>Ultima II - Revenge of the Enchantress </description>
+<year>1983</year>
+<publisher>Master</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="684db5c6" name="Ultima II - Revenge of the Enchantress (1983)(On-Line Systems)(Disk 2 of 4)(Master).dsk" offset="0" sha1="56ac22c53f7abae9316d0592dce5787f" size="143360" /></dataarea></part></software>
+<software name="UltimaII">
+<description>Ultima II - Revenge of the Enchantress </description>
+<year>1983</year>
+<publisher>Player</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="407903bc" name="Ultima II - Revenge of the Enchantress (1983)(On-Line Systems)(Disk 3 of 4)(Player).dsk" offset="0" sha1="1d4706eb6c96d9e2e58537914f8a50a8" size="143360" /></dataarea></part></software>
+<software name="UltimaII">
+<description>Ultima II - Revenge of the Enchantress </description>
+<year>1983</year>
+<publisher>Galaxy</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2b2bfc38" name="Ultima II - Revenge of the Enchantress (1983)(On-Line Systems)(Disk 4 of 4)(Galaxy).dsk" offset="0" sha1="4009dad9f2d6882514c5a9b0c164abba" size="143360" /></dataarea></part></software>
+<software name="UltimaV-">
+<description>Ultima V - Warriors of Destiny </description>
+<year>1988</year>
+<publisher>Underworld</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="52120">
+<rom crc="4a399ddf" name="Ultima V - Warriors of Destiny (1988)(Origin)(Disk 8 of 8)(Underworld).dsk" offset="0" sha1="525852465c390c98bf93b7ae1de30af0" size="52120" /></dataarea></part></software>
+<software name="Universecr">
+<description>Universe v1.1 </description>
+<year>1984</year>
+<publisher>Disk 1 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="66efa5ab" name="Universe v1.1 (1984)(Omnitrend Software)(Disk 1 of 5)[cr].dsk" offset="0" sha1="779025b0647625379af934f0b89afb5e" size="143360" /></dataarea></part></software>
+<software name="Universecr">
+<description>Universe v1.1 </description>
+<year>1984</year>
+<publisher>Disk 2 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c01dec92" name="Universe v1.1 (1984)(Omnitrend Software)(Disk 2 of 5)[cr].dsk" offset="0" sha1="6293857597735881eb152d4caf88026b" size="143360" /></dataarea></part></software>
+<software name="Universecr">
+<description>Universe v1.1 </description>
+<year>1984</year>
+<publisher>Disk 3 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a9244084" name="Universe v1.1 (1984)(Omnitrend Software)(Disk 3 of 5)[cr].dsk" offset="0" sha1="8631dd2ec06dc2d3f50be71829f14106" size="143360" /></dataarea></part></software>
+<software name="Universecr">
+<description>Universe v1.1 </description>
+<year>1984</year>
+<publisher>Disk 4 of 5</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="06582169" name="Universe v1.1 (1984)(Omnitrend Software)(Disk 4 of 5)[cr].dsk" offset="0" sha1="1aba69dee13a19dae75894c99fde4783" size="143360" /></dataarea></part></software>
+<software name="Universecr">
+<description>Universe v1.1 </description>
+<year>1984</year>
+<publisher>Player</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="02d271b2" name="Universe v1.1 (1984)(Omnitrend Software)(Disk 5 of 5)(Player)[cr].dsk" offset="0" sha1="20181c6bf8bf7a785773d28f4d71571a" size="143360" /></dataarea></part></software>
+<software name="Up'n'DowcrB">
+<description>Up 'n' Down </description>
+<year>1984</year>
+<publisher>Sega</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c0c80c30" name="Up 'n' Down (1984)(Sega)[cr Black Bag].dsk" offset="0" sha1="255aacb11a0d54de3fdd4f9128159ff8" size="143360" /></dataarea></part></software>
+<software name="WarinRusRDO">
+<description>War in Russia </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="942a81ed" name="War in Russia (1983)(SSI)(Disk 1 of 2)[RDOS].dsk" offset="0" sha1="4c27ab3e609dc812ebb3ec8440b67087" size="143360" /></dataarea></part></software>
+<software name="WarinRusRDO">
+<description>War in Russia </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="af29147d" name="War in Russia (1983)(SSI)(Disk 2 of 2)[RDOS].dsk" offset="0" sha1="1672e8230686b680b7c808ea285ea38d" size="143360" /></dataarea></part></software>
+<software name="WarofthecrU">
+<description>War of the Lance </description>
+<year>1989</year>
+<publisher>Disk 1 of 2 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="07b5faa7" name="War of the Lance (1989)(SSI)(Disk 1 of 2 Side A)[cr USAlliance][RDOS].dsk" offset="0" sha1="6ca2560008ff1d2f76641d148d046dc2" size="143360" /></dataarea></part></software>
+<software name="WarofthecrU">
+<description>War of the Lance </description>
+<year>1989</year>
+<publisher>Disk 1 of 2 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4e8b2c01" name="War of the Lance (1989)(SSI)(Disk 1 of 2 Side B)[cr USAlliance][RDOS].dsk" offset="0" sha1="317a5498abe190ae1ee68196315204a4" size="143360" /></dataarea></part></software>
+<software name="WarofthecrU">
+<description>War of the Lance </description>
+<year>1989</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="eee0e01e" name="War of the Lance (1989)(SSI)(Disk 2 of 2)[cr USAlliance][RDOS].dsk" offset="0" sha1="d52c9f2c14e443a4cc5e925ec296a2a5" size="143360" /></dataarea></part></software>
+<software name="WarpDestcrC">
+<description>Warp Destroyer </description>
+<year>1982</year>
+<publisher>Thomas Ball - Eric Varsanyi</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="287564ac" name="Warp Destroyer (1982)(Thomas Ball - Eric Varsanyi)[cr Corrupt Computing].dsk" offset="0" sha1="9a82b7bbd703170e43083870a5553045" size="143360" /></dataarea></part></software>
+<software name="WarpinthRDO">
+<description>Warp in the South Pacific </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ee481e99" name="Warp in the South Pacific (1986)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="c0d44c9a3a70f5c7d72fc35a239e3a86" size="143360" /></dataarea></part></software>
+<software name="WarpinthRDO">
+<description>Warp in the South Pacific </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="b936c071" name="Warp in the South Pacific (1986)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="1e1100979f1d01bbf5031692e5383983" size="143360" /></dataarea></part></software>
+<software name="WarshipvRDO">
+<description>Warship v1.1 </description>
+<year>1986</year>
+<publisher>SSI</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7f3ba69e" name="Warship v1.1 (1986)(SSI)[RDOS].dsk" offset="0" sha1="ef3ce09665267957ff5d55b27769a5ff" size="143360" /></dataarea></part></software>
+<software name="WastelancrC">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 1 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0b9acdb1" name="Wasteland (1987)(Electronic Arts)(Disk 1 of 4 Side A)[cr Crackforce].dsk" offset="0" sha1="d7530f1821131dc54a08a12a85b5ede9" size="143360" /></dataarea></part></software>
+<software name="WastelancrC">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 1 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ea57131c" name="Wasteland (1987)(Electronic Arts)(Disk 1 of 4 Side B)[cr Crackforce].dsk" offset="0" sha1="8942c0af30f7d4d8a8c3061d28eb3dff" size="143360" /></dataarea></part></software>
+<software name="WastelancrC">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 1 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="07291123" name="Wasteland (1987)(Electronic Arts)(Disk 1 of 4 Side B)[cr Crackforce][a].dsk" offset="0" sha1="9fc328d5eab51b6b52952f941160adf7" size="143360" /></dataarea></part></software>
+<software name="WastelancrB">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0bdcbc20" name="Wasteland (1987)(Electronic Arts)(Disk 1 of 4)[cr Blade].dsk" offset="0" sha1="82a7881429ade038dae98c5e98b7ef25" size="143360" /></dataarea></part></software>
+<software name="WastelancrB">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 1 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e99711e7" name="Wasteland (1987)(Electronic Arts)(Disk 1 of 4)[cr Blade][a].dsk" offset="0" sha1="a400d3fae186a6934747e4d8bd4dba0e" size="143360" /></dataarea></part></software>
+<software name="WastelancrC">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 2 of 4 Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="456544dc" name="Wasteland (1987)(Electronic Arts)(Disk 2 of 4 Side A)[cr Crackforce].dsk" offset="0" sha1="8369f8bd8971ac160998b6b44d40dd8a" size="143360" /></dataarea></part></software>
+<software name="WastelancrC">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 2 of 4 Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4ec6ec73" name="Wasteland (1987)(Electronic Arts)(Disk 2 of 4 Side B)[cr Crackforce].dsk" offset="0" sha1="e54a6559ac78c2ec08e34efa291ab5f8" size="143360" /></dataarea></part></software>
+<software name="WastelancrB">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 2 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="07ef903c" name="Wasteland (1987)(Electronic Arts)(Disk 2 of 4)[cr Blade].dsk" offset="0" sha1="b45b734ad80a298b78545f1136a2b382" size="143360" /></dataarea></part></software>
+<software name="WastelancrB">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 3 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="93b3e734" name="Wasteland (1987)(Electronic Arts)(Disk 3 of 4)[cr Blade].dsk" offset="0" sha1="726808fc1cbadd3972cc61c0d017c505" size="143360" /></dataarea></part></software>
+<software name="WastelancrB">
+<description>Wasteland </description>
+<year>1987</year>
+<publisher>Disk 4 of 4</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bc221c14" name="Wasteland (1987)(Electronic Arts)(Disk 4 of 4)[cr Blade].dsk" offset="0" sha1="83511ff1c90f517a0edcb59b0e080f27" size="143360" /></dataarea></part></software>
+<software name="WayOutcrK">
+<description>Way Out </description>
+<year>1982</year>
+<publisher>Sirius Software</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="01b1b64c" name="Way Out (1982)(Sirius Software)[cr Krakowicz].dsk" offset="0" sha1="8c41cd629598994d6d4e87f0b27033ac" size="143360" /></dataarea></part></software>
+<software name="WhereintcrB">
+<description>Where in the USA is Carmen Sandiego </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="5e01b8df" name="Where in the USA is Carmen Sandiego (1986)(Broderbund)(Side A)[cr Bank of Pirated Software][16 sectors version].dsk" offset="0" sha1="e6aa50c666af69d440493d749a31cd97" size="143360" /></dataarea></part></software>
+<software name="WhereintcrE">
+<description>Where in the USA is Carmen Sandiego </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="72c96e2a" name="Where in the USA is Carmen Sandiego (1986)(Broderbund)(Side A)[cr Evil Sock - Optimus Prime].dsk" offset="0" sha1="a0ad053cf2d7b9eb7ff46efba763d4c3" size="143360" /></dataarea></part></software>
+<software name="WhereintcrE">
+<description>Where in the USA is Carmen Sandiego </description>
+<year>1986</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f758f0b8" name="Where in the USA is Carmen Sandiego (1986)(Broderbund)(Side A)[cr Evil Sock - Optimus Prime][a].dsk" offset="0" sha1="126b226e9de4dced5b3d748bfb8c9479" size="143360" /></dataarea></part></software>
+<software name="WhereintcrB">
+<description>Where in the USA is Carmen Sandiego </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="867c1dc5" name="Where in the USA is Carmen Sandiego (1986)(Broderbund)(Side B)[cr Bank of Pirated Software][16 sectors version].dsk" offset="0" sha1="04c0ecdbe7cf26ea10d364b5362f7b67" size="143360" /></dataarea></part></software>
+<software name="WhereintcrE">
+<description>Where in the USA is Carmen Sandiego </description>
+<year>1986</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1c122b58" name="Where in the USA is Carmen Sandiego (1986)(Broderbund)(Side B)[cr Evil Sock - Optimus Prime].dsk" offset="0" sha1="c0ef0927e249f14b44e1aa874148f2fe" size="143360" /></dataarea></part></software>
+<software name="WhiteWatcrD">
+<description>White Water Canoe Race, The </description>
+<year>1984</year>
+<publisher>Solutions Unlimited</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2164aa60" name="White Water Canoe Race, The (1984)(Solutions Unlimited)[cr Digital Gang].dsk" offset="0" sha1="ad76854df6e2e5c59ab9441fd8def8ec" size="143360" /></dataarea></part></software>
+<software name="Wilderne">
+<description>Wilderness </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9c47b52d" name="Wilderness (1984)(Titan)(Disk 1 of 2).dsk" offset="0" sha1="a75b75d0f603f72edd9e8fed311e5dab" size="143360" /></dataarea></part></software>
+<software name="Wilderne">
+<description>Wilderness </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c2dd571f" name="Wilderness (1984)(Titan)(Disk 2 of 2).dsk" offset="0" sha1="4a2ac4d46aa5aba71ef780e350d3faa8" size="143360" /></dataarea></part></software>
+<software name="WinLoseo">
+<description>Win, Lose or Draw - 2nd Edition </description>
+<year>1988</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="89387cea" name="Win, Lose or Draw - 2nd Edition (1988)(Softie)(Disk 1 of 2).dsk" offset="0" sha1="394feb95983c59f605497233b4319301" size="143360" /></dataarea></part></software>
+<software name="WinLoseo">
+<description>Win, Lose or Draw - 2nd Edition </description>
+<year>1988</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="977a89f9" name="Win, Lose or Draw - 2nd Edition (1988)(Softie)(Disk 2 of 2).dsk" offset="0" sha1="a40e184c1f3e244e683cbcf6838c793b" size="143360" /></dataarea></part></software>
+<software name="WingsofF">
+<description>Wings of Fury </description>
+<year>1987</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="566b4571" name="Wings of Fury (1987)(Broderbund)(Side A).dsk" offset="0" sha1="3c403667de51458e0398de91fe4ea68f" size="143360" /></dataarea></part></software>
+<software name="WingsofF">
+<description>Wings of Fury </description>
+<year>1987</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="03ef6d37" name="Wings of Fury (1987)(Broderbund)(Side B).dsk" offset="0" sha1="35b825e12aeada243cdb99bf3e1fc30b" size="143360" /></dataarea></part></software>
+<software name="WinterGacrD">
+<description>Winter Games </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9ebb0f31" name="Winter Games (1985)(Epyx)(Side A)[cr Digital Gang].dsk" offset="0" sha1="697c29ab3571d7596addd7528b016dab" size="143360" /></dataarea></part></software>
+<software name="WinterGacrG">
+<description>Winter Games </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="45d284d0" name="Winter Games (1985)(Epyx)(Side A)[cr Gonif].dsk" offset="0" sha1="36b571d0ea8db4480251909c883198a5" size="143360" /></dataarea></part></software>
+<software name="WinterGacrD">
+<description>Winter Games </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9932afb3" name="Winter Games (1985)(Epyx)(Side B)[cr Digital Gang].dsk" offset="0" sha1="8de6f0802573dc1df3bf32f6848b83c7" size="143360" /></dataarea></part></software>
+<software name="Wishbrin">
+<description>Wishbringer </description>
+<year>1985</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1fa1c321" name="Wishbringer (1985)(Infocom).dsk" offset="0" sha1="035628476d186737027865d6fa4eadfc" size="143360" /></dataarea></part></software>
+<software name="WitnessT">
+<description>Witness, The </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6043d087" name="Witness, The (1983)(Infocom).dsk" offset="0" sha1="bf07b7a77175c4d78d2f74d562bf6629" size="143360" /></dataarea></part></software>
+<software name="WitnessTa">
+<description>Witness, The </description>
+<year>1983</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="905604d4" name="Witness, The (1983)(Infocom)[a].dsk" offset="0" sha1="f6c297deb5a786d4b0588e748c225116" size="143360" /></dataarea></part></software>
+<software name="WizardancrL">
+<description>Wizard and the Princess </description>
+<year>1986</year>
+<publisher>Green Valley Publishing</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="7040589c" name="Wizard and the Princess (1986)(Green Valley Publishing)[cr Late Night Crew].dsk" offset="0" sha1="9110002bfa805d4c87712ca5c508efce" size="143360" /></dataarea></part></software>
+<software name="Wizard'sRDO">
+<description>Wizard's Crown v1.0 </description>
+<year>1985</year>
+<publisher>Side A</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="cb4489e8" name="Wizard's Crown v1.0 (1985)(SSI)(Side A)[RDOS].dsk" offset="0" sha1="1a2dd8286ad635647e5665fd8f391d1e" size="143360" /></dataarea></part></software>
+<software name="Wizard'sRDO">
+<description>Wizard's Crown v1.0 </description>
+<year>1985</year>
+<publisher>Side B</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="92d20862" name="Wizard's Crown v1.0 (1985)(SSI)(Side B)[RDOS].dsk" offset="0" sha1="987b45b86321b2212daac51de596e136" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry </description>
+<year>1981</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a08f3c35" name="Wizardry (1981)(Andrew Greenberg)(Disk 1 of 2)[PASCAL].dsk" offset="0" sha1="20028d5049a558bab45fa413e75fd59f" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry </description>
+<year>1981</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="472ae136" name="Wizardry (1981)(Andrew Greenberg)(Disk 2 of 2)[PASCAL].dsk" offset="0" sha1="031f14562c2ea57c11521fb29e320b78" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry II - Knight And Diamons </description>
+<year>1982</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a57dde8a" name="Wizardry II - Knight And Diamons (1982)(Andrew Greenberg)(Disk 1 of 2)[PASCAL].dsk" offset="0" sha1="bdf7b6a560d5446a75ffca07edeed244" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry II - Knight And Diamons </description>
+<year>1982</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d69c4042" name="Wizardry II - Knight And Diamons (1982)(Andrew Greenberg)(Disk 2 of 2)[PASCAL].dsk" offset="0" sha1="c6b955b457345d00a84cfd33bddcdc83" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry III - The Legacy of Llylgamyn </description>
+<year>1983</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ec450452" name="Wizardry III - The Legacy of Llylgamyn (1983)(Andrew Greenberg)(Disk 1 of 2)[PASCAL].dsk" offset="0" sha1="acec506bac163d081c7d2bcd71f90081" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry III - The Legacy of Llylgamyn </description>
+<year>1983</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f67ecb05" name="Wizardry III - The Legacy of Llylgamyn (1983)(Andrew Greenberg)(Disk 2 of 2)[PASCAL].dsk" offset="0" sha1="f653e3ad26754eb2570b7d53809984fa" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 1 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="044dd9c7" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 1 of 6)[PASCAL].dsk" offset="0" sha1="43a70c17cf7535cb9d53a5e5dea4ad51" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 2 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="26bd1552" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 2 of 6).dsk" offset="0" sha1="5f9e9a39253481aab54ff2c72c7e1d22" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 3 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f20bbcfb" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 3 of 6).dsk" offset="0" sha1="8a6ef296bfdbd4a28388a1c0822112cf" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 4 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="16b53876" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 4 of 6).dsk" offset="0" sha1="6a57fffff0ec82c61a5ae1b7a5b05694" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 5 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="54caef0f" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 5 of 6).dsk" offset="0" sha1="05b51606d6bc5e610aa695713183b986" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry IV - The Return of Werdna </description>
+<year>1987</year>
+<publisher>Disk 6 of 6</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e08d6f21" name="Wizardry IV - The Return of Werdna (1987)(Sir-Tech Software)(Disk 6 of 6)[PASCAL].dsk" offset="0" sha1="2e8c4cb6bec00b98c2f6683e557e0109" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry Scenary Editor </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="18173f2e" name="Wizardry Scenary Editor (19xx)(-)[PASCAL].dsk" offset="0" sha1="bcfe0f5fbc1e309cf2eee862b7f41be5" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 1 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="83275f9e" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 1 of 9)[a][PASCAL].dsk" offset="0" sha1="4c300964d231ff5740dca4bd1871f08c" size="143360" /></dataarea></part></software>
+<software name="WizardryPAS">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 1 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="069eebd1" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 1 of 9)[PASCAL].dsk" offset="0" sha1="357182f7134a8ab5bcdfb1ba66e09d94" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 2 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="529d68d8" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 2 of 9).dsk" offset="0" sha1="8fc4cde240aec6d74eeffa0ca293dd86" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 2 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0c20dd06" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 2 of 9)[a].dsk" offset="0" sha1="2f2c3c45d9bf4ba5eb8ec41786b87a02" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 3 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="32027a88" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 3 of 9).dsk" offset="0" sha1="4c43309eb3970df75d6674a65faf36a7" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 3 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="4031976e" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 3 of 9)[a].dsk" offset="0" sha1="a2b75dc1ef85c9c026a5f4c8c1d6f871" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 4 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="478aee0a" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 4 of 9).dsk" offset="0" sha1="4c12c945274edd78c32dd3693fa3c61a" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 4 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e020438d" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 4 of 9)[a].dsk" offset="0" sha1="f5509eb0c9a6d07d4cc65bcb3af0b978" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 5 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="679d220e" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 5 of 9)[a].dsk" offset="0" sha1="97ec7cf35727282b44727f381be8b7ac" size="143360" /></dataarea></part></software>
+<software name="Wizardryb">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 5 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0d9b084a" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 5 of 9)[b].dsk" offset="0" sha1="88fa2ae656e682b2a256c53962ed7e2a" size="143360" /></dataarea></part></software>
+<software name="Wizardryf">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 5 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8918b805" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 5 of 9)[f].dsk" offset="0" sha1="30b7573e32e46a8828fccf281e2892ff" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 6 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="579bf173" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 6 of 9).dsk" offset="0" sha1="7e5a009fe82ffff75dc859937cb94346" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 6 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="05e181b1" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 6 of 9)[a].dsk" offset="0" sha1="21d11b5a19c1ba1b930d9d7d89775eae" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 7 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e86c6e68" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 7 of 9).dsk" offset="0" sha1="2d99d89ee98624ff754067cfb5f3f69b" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 7 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="bd308af5" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 7 of 9)[a].dsk" offset="0" sha1="c9137c7486a5d48a09c24a33feaf36cb" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 8 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="6917b0a2" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 8 of 9).dsk" offset="0" sha1="47fb69450f7aaa71618c31ee6c3daa03" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 8 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="42e68e0a" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 8 of 9)[a].dsk" offset="0" sha1="947a02b3ac14585fd0262f6366f04c14" size="143360" /></dataarea></part></software>
+<software name="Wizardry">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 9 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="c9356454" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 9 of 9).dsk" offset="0" sha1="16e05d035a9beb89fc9b6dc03672f05e" size="143360" /></dataarea></part></software>
+<software name="Wizardrya">
+<description>Wizardry V - Heart of the Maelstrom </description>
+<year>1988</year>
+<publisher>Disk 9 of 9</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d21bad67" name="Wizardry V - Heart of the Maelstrom (1988)(Sir-Tech Software)(Disk 9 of 9)[a].dsk" offset="0" sha1="2478005543b78930a96663f87aa574fd" size="143360" /></dataarea></part></software>
+<software name="WizplusPAS">
+<description>Wizplus </description>
+<year>1982</year>
+<publisher>Datamost</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="f2925573" name="Wizplus (1982)(Datamost)[PASCAL].dsk" offset="0" sha1="8961281f551879ff23be3af86daf2202" size="143360" /></dataarea></part></software>
+<software name="WizplusPAS">
+<description>Wizplus </description>
+<year>1982</year>
+<publisher>Datsoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="adc76658" name="Wizplus (1982)(Datsoft)[PASCAL].dsk" offset="0" sha1="47c5308e7a1fedb2a235407924c31653" size="143360" /></dataarea></part></software>
+<software name="WordChalcrM">
+<description>Word Challenge </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="62172320" name="Word Challenge (19xx)(-)[cr Mr. Krac-Man].dsk" offset="0" sha1="c4c1d5da18c7478f3934b0771bfa9160" size="143360" /></dataarea></part></software>
+<software name="WordChalcrM">
+<description>Word Challenge </description>
+<year>19xx</year>
+<publisher>-</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="60c10e23" name="Word Challenge (19xx)(-)[cr Mr. Krac-Man][a].dsk" offset="0" sha1="93a1bd714ead2a01cd92e94b98b93bdc" size="143360" /></dataarea></part></software>
+<software name="World'sGcrN">
+<description>World's Greatest Baseball Game, The </description>
+<year>1984</year>
+<publisher>Epyx</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0a51e86b" name="World's Greatest Baseball Game, The (1984)(Epyx)[cr New Regime - Shaolin Disciples].dsk" offset="0" sha1="ff586bb611b708c61eec48e6c5706eb0" size="143360" /></dataarea></part></software>
+<software name="Xyphus">
+<description>Xyphus </description>
+<year>1984</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1ba1a632" name="Xyphus (1984)(Penguin Software)(Disk 1 of 2).dsk" offset="0" sha1="178492e878d0d239b2530d01d748fe00" size="143360" /></dataarea></part></software>
+<software name="Xyphus">
+<description>Xyphus </description>
+<year>1984</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="55de3f0f" name="Xyphus (1984)(Penguin Software)(Disk 2 of 2).dsk" offset="0" sha1="71f07ce2a405c72fc38d5deb89b7c396" size="143360" /></dataarea></part></software>
+<software name="Zaxxon">
+<description>Zaxxon </description>
+<year>1983</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d1bb8060" name="Zaxxon (1983)(Datasoft).dsk" offset="0" sha1="69f2f39ce6da06561ee459ea4ad3be41" size="143360" /></dataarea></part></software>
+<software name="ZaxxoncrM">
+<description>Zaxxon </description>
+<year>1983</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="24885bd5" name="Zaxxon (1983)(Datasoft)[cr Midwest Pirates Guild].dsk" offset="0" sha1="6d23bd2e3414c496602ab01faca04fb8" size="143360" /></dataarea></part></software>
+<software name="ZaxxoncrS">
+<description>Zaxxon </description>
+<year>1983</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="e4c8c106" name="Zaxxon (1983)(Datasoft)[cr Software-Freak].dsk" offset="0" sha1="523c111bf39088d76dba65da9406f8eb" size="143360" /></dataarea></part></software>
+<software name="ZorkI-Th">
+<description>Zork I - The Great Underground Empire </description>
+<year>1980</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="2467e294" name="Zork I - The Great Underground Empire (1980)(Infocom).dsk" offset="0" sha1="e8061c4334e650a4aae4a634d0c35fa8" size="143360" /></dataarea></part></software>
+<software name="ZorkI-Th40-">
+<description>Zork I - The Great Underground Empire </description>
+<year>1980</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="49a004e0" name="Zork I - The Great Underground Empire (1980)(Infocom)[40-column version][PASCAL].dsk" offset="0" sha1="a4dffeda3af85feb522a26b7c5ba33fe" size="143360" /></dataarea></part></software>
+<software name="ZorkI-Tha">
+<description>Zork I - The Great Underground Empire </description>
+<year>1980</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="07c67140" name="Zork I - The Great Underground Empire (1980)(Infocom)[a][PASCAL].dsk" offset="0" sha1="1f948394620dddffe47a2f6d81e62d0e" size="143360" /></dataarea></part></software>
+<software name="ZorkI-Tho">
+<description>Zork I - The Great Underground Empire </description>
+<year>1980</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143488">
+<rom crc="959603d6" name="Zork I - The Great Underground Empire (1980)(Infocom)[o].dsk" offset="0" sha1="8eba35bbce2a4d92292e6e9c5b06c468" size="143488" /></dataarea></part></software>
+<software name="ZorkI-ThPAS">
+<description>Zork I - The Great Underground Empire </description>
+<year>1980</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="85c9d27d" name="Zork I - The Great Underground Empire (1980)(Infocom)[PASCAL].dsk" offset="0" sha1="251f615ffe0bf05825ddc4f3cb198fc5" size="143360" /></dataarea></part></software>
+<software name="ZorkII-Ta">
+<description>Zork II - The Wizard of Frobozz </description>
+<year>1981</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="d5b38d7e" name="Zork II - The Wizard of Frobozz (1981)(Infocom)[a].dsk" offset="0" sha1="c2d414f48e3dc8ffba8f928dea9aac37" size="143360" /></dataarea></part></software>
+<software name="ZorkII-TPAS">
+<description>Zork II - The Wizard of Frobozz </description>
+<year>1981</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="8f050e66" name="Zork II - The Wizard of Frobozz (1981)(Infocom)[PASCAL].dsk" offset="0" sha1="646a0d8c8588438578ab80148a42b711" size="143360" /></dataarea></part></software>
+<software name="ZorkIII-">
+<description>Zork III - The Dungeon Master </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="3969b21d" name="Zork III - The Dungeon Master (1982)(Infocom).dsk" offset="0" sha1="6e5763ca58ae1609e034e1ea3bec60a7" size="143360" /></dataarea></part></software>
+<software name="ZorkIII-a">
+<description>Zork III - The Dungeon Master </description>
+<year>1982</year>
+<publisher>Infocom</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="1d598608" name="Zork III - The Dungeon Master (1982)(Infocom)[a].dsk" offset="0" sha1="dea5b0d0fd4611e1a5f9b2a896ff306c" size="143360" /></dataarea></part></software>
+<software name="Zorrocr">
+<description>Zorro </description>
+<year>1985</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="0d76f450" name="Zorro (1985)(Datasoft)(Disk 1 of 2)[cr].dsk" offset="0" sha1="6cef63c6a525b44ca14918844d0f523d" size="143360" /></dataarea></part></software>
+<software name="Zorrocr">
+<description>Zorro </description>
+<year>1985</year>
+<publisher>Disk 1 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="9a3fb8e9" name="Zorro (1985)(Datasoft)(Disk 1 of 2)[cr][a].dsk" offset="0" sha1="4e363e191fcc68c43afc4bc897d85b5f" size="143360" /></dataarea></part></software>
+<software name="Zorrocr">
+<description>Zorro </description>
+<year>1985</year>
+<publisher>Disk 2 of 2</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="a526d021" name="Zorro (1985)(Datasoft)(Disk 2 of 2)[cr].dsk" offset="0" sha1="66a7fc67b8ddabb0e044840dc86f9934" size="143360" /></dataarea></part></software>
+<software name="ZorrocrB">
+<description>Zorro </description>
+<year>1985</year>
+<publisher>Datasoft</publisher>
+<part interface="floppy_5_25" name="flop1">
+<dataarea name="flop1" size="143360">
+<rom crc="ffa0f5b3" name="Zorro (1985)(Datasoft)[cr Blade].dsk" offset="0" sha1="867f1c24eb2debb0546012c63696d415" size="143360" /></dataarea></part></software></softwarelist>


### PR DESCRIPTION
Based on the TOSEC list, use the apple2p driver as that will autoboot, rather than the apple2 driver which drops into the monitor program.
