### PR TITLE
Fix a800.xml slot device name (cart1)

### DIFF
--- a/Binaries/hash/a800.xml
+++ b/Binaries/hash/a800.xml
@@ -352,7 +352,7 @@ Compiled by K1W1
 		<description>400/800 SALT Diagnostic Cartridge v1.00</description>
 		<year>1979</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="400-800 salt diagnostic cartridge v1.00.rom" size="8192" crc="1bd00850" sha1="37e2fb5efa6043d1bb28b9661c218522f45c7d3c" offset="0" />
@@ -364,7 +364,7 @@ Compiled by K1W1
 		<description>400/800 SALT Diagnostic Cartridge v2.04</description>
 		<year>1981</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="400-800 salt diagnostic cartridge v2.04.rom" size="8192" crc="3e304b52" sha1="8e24e9f2d73a3ce8cd63f8f0ab4e9522ec23d5d4" offset="0" />
@@ -377,7 +377,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="TE15644" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="s400-800 salt diagnostic cartridge v2.05.rom" size="8192" crc="f269cc0a" sha1="a51f73b23b6fdfd69a2e54b3369d3979677b28b3" offset="0" />
@@ -389,7 +389,7 @@ Compiled by K1W1
 		<description>600xl/800xl SALT Diagnostic Cartridge vSE.02</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="600xl-800xl salt diagnostic cartridge vse.02.rom" size="16384" crc="dc1e9fd4" sha1="f0586a2c86b0e1d969f44a5d39dbf62204d25ba6" offset="0" />
@@ -402,7 +402,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="FD100006" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="4096">
 				<rom name="810 diagnostic cartridge.rom" size="4096" crc="f3627929" sha1="ea47f59cae92801eee01e28a6cfdb76740edd906" offset="0" /> <!-- Verified -->
@@ -414,7 +414,7 @@ Compiled by K1W1
 		<description>1400 Super SALT Diagnostic Cartridge (Rev.C01)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="1400 super salt rev.c01.rom" size="16384" crc="10cb0520" sha1="994e48b05d2190e341d463696eff96c6e68eb843" offset="0" status="baddump" />
@@ -428,7 +428,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8050" />
 		<info name="usage" value="To be used with Atari 1400 onboard modem." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="1400 telecommunicator (proto).rom" size="16384" crc="c63d9e1c" sha1="53d1ae6e301931a272f50253cccf7f8e69f91b72" offset="0" />
@@ -441,7 +441,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4010" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="3d tic-tac-toe.rom" size="8192" crc="4660c404" sha1="9e70098ab2598edd9c2913d787554590733c49a0" offset="0" /> <!-- Verified -->
@@ -453,7 +453,7 @@ Compiled by K1W1
 		<description>Abracadabra</description>
 		<year>1983</year>
 		<publisher>TG Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="abracadabra.rom" size="16384" crc="a35c775d" sha1="ed888289ee6c37ac3fa8b80e7e3250c7ca718fcd" offset="0" /> <!-- Verified -->
@@ -468,7 +468,7 @@ Compiled by K1W1
 		<publisher>Amiable Computer Enhancements</publisher>
 		<info name="serial" value="DT-80" />
 		<sharedfeat name="compatibility" value="XL/XE"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="ace-80xl.rom" size="16384" crc="4d148a37" sha1="87887ffdd14cdaa0608460333f385a912030c18c" offset="0" />
@@ -481,7 +481,7 @@ Compiled by K1W1
 		<!-- This cartridge is used with an 400/800 series computer interfaced to an ATR-8000 to enable an 80 column display. -->
 		<year>1984</year>
 		<publisher>Amiable Computer Enhancements</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="dt80.rom" size="8192" crc="7840a595" sha1="89078a0c8271fef33a7001ff7b5cb0f743d66d27" offset="0" />
@@ -494,7 +494,7 @@ Compiled by K1W1
 		<!-- One chip cartridge. -->
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="action! programming language v3.6.rom" size="16384" crc="a1f90dfd" sha1="03b31582133c4883f470ef08c7b9eaad71fc8710" offset="0" /> <!-- Verified -->
@@ -507,7 +507,7 @@ Compiled by K1W1
 		<!-- Two chip cartridge. -->
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss034m" />
 			<dataarea name="rom" size="16384">
 				<rom name="action! programming language v3.6 (alt).rom" size="16384" crc="eb905cb4" sha1="a9db2200bda7980436461e2d48d02f2a3f3b54ac" offset="0" /> <!-- Verified -->
@@ -519,7 +519,7 @@ Compiled by K1W1
 		<description>Action! Programming Language v3.5</description>
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss043m" />
 			<dataarea name="rom" size="16384">
 				<rom name="action! programming language v3.5.rom" size="16384" crc="ae298a33" sha1="8928a0c6a93e5b78aa3f91d8bd25b2e529e274ae" offset="0" />
@@ -532,7 +532,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="ADV-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="adventure creator.rom" size="16384" crc="8746d9da" sha1="2e457c53969f6d8995049ce89b13204fcb79627d" offset="0" /> <!-- Verified -->
@@ -546,7 +546,7 @@ Compiled by K1W1
 		<publisher>Spinnaker</publisher>
 		<info name="developer" value="Joyce Hakansson Associates, Inc" />
 		<info name="serial" value="ALF-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="alf in the color caves.rom" size="16384" crc="79df7f9d" sha1="d197de362de419f5963af89fc7ce34074c84ce10" offset="0" /> <!-- Verified -->
@@ -559,7 +559,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="AED80014" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atarilab light module.rom" size="16384" crc="9be1c9e4" sha1="f2dbf1ce1b49361492dafc5d09b91b1de07dc247" offset="0" /> <!-- Verified -->
@@ -572,7 +572,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="AED80013" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atarilab temperature module.rom" size="16384" crc="4036e465" sha1="5119a0ac7cc7c6d27954b7522a2f40c47f136f08" offset="0" /> <!-- Verified -->
@@ -584,7 +584,7 @@ Compiled by K1W1
 		<description>Alien Ambush</description>
 		<year>1983</year>
 		<publisher>DANA</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="alien ambush.rom" size="8192" crc="ad7bc30b" sha1="aba31902c7cda455c228bb3af6b7bb55422ea02d" offset="0" /> <!-- Verified -->
@@ -597,7 +597,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="544R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="alien garden.rom" size="8192" crc="3e27ed0f" sha1="2a37f69183eb708dc843d3c38590c30f83a89ccd" offset="0" /> <!-- Verified -->
@@ -610,7 +610,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33022" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="alpha shield.rom" size="8192" crc="484e8443" sha1="1374b53f9c8c759edc933db96fe3ad13b241a5ad" offset="0" /> <!-- Verified -->
@@ -623,7 +623,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="ABZ-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="alphabet zoo.rom" size="16384" crc="c9613ecd" sha1="d7fe5688cf754615db87b5d031361fae9fcaada4" offset="0" /> <!-- Verified -->
@@ -635,7 +635,7 @@ Compiled by K1W1
 		<description>Animated Puzzle (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="animated puzzle.rom" size="16384" crc="90f37afe" sha1="d4330929400b53faf7075729179b56b4e4b2894f" offset="0" />
@@ -648,7 +648,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Romox</publisher>
 		<info name="serial" value="05023" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="ant eater.rom" size="8192" crc="c7290722" sha1="8a8031ac9611c119d6b4c90303460556a3321fd7" offset="0" />
@@ -661,7 +661,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Romox</publisher>
 		<info name="serial" value="05023" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="ant eater (earlier version).rom" size="8192" crc="73a3a64c" sha1="5a00dde544d5f31b03e291c0889724c11a153375" offset="0" />
@@ -673,7 +673,7 @@ Compiled by K1W1
 		<description>Arex (Pirate)</description>
 		<year>1983</year>
 		<publisher>Adventure International</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="arex.rom" size="16384" crc="2a080e7d" sha1="db2db86dbbea35769370590cc6880fab6bff1266" offset="0" />
@@ -687,7 +687,7 @@ Compiled by K1W1
 		<year>1980</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4003, RXG4003 (GER)" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="assembler editor computing language.rom" size="8192" crc="ee72eeea" sha1="b9f0efedd8486d8034b25c5eedac4946bc70aa8d" offset="0" /> <!-- Verified -->
@@ -700,7 +700,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4003" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="editor assembler computing language.rom" size="8192" crc="7dd6196c" sha1="42cb5fc35c76fde8cdf0c67db96a1c8a97af57ee" offset="0" /> <!-- Verified -->
@@ -717,7 +717,7 @@ Compiled by K1W1
 		     a certain time, and this isn't currently emulated. -->
 		<year>19??</year>
 		<publisher>&lt;unknown&gt;</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="N/A" />
 			<dataarea name="rom" size="16384">
 				<rom name="ast 2000.rom" size="16384" crc="e9da4eaa" sha1="7590ef4519ff33a80bb9a19a1dc903c44edcbc69" offset="0" />
@@ -730,7 +730,7 @@ Compiled by K1W1
 		<!-- Turbo Tape utility for Atari XC12 Tape Recorders. -->
 		<year>1988</year>
 		<publisher>Atari Studio</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_phoenix" />
 			<dataarea name="rom" size="8192">
 				<rom name="ast (atari super turbo) for atari xc12" size="8192" crc="45c1ff0c" sha1="4f95a65a2f85cf8525576be067f426c278b9cf10" offset="0" />
@@ -743,7 +743,7 @@ Compiled by K1W1
 		<!-- Turbo Tape utility for Atari 1010 Tape Recorders. -->
 		<year>1988</year>
 		<publisher>Atari Studio</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_phoenix" />
 			<dataarea name="rom" size="8192">
 				<rom name="ast (atari super turbo) for atari 1010.rom" size="8192" crc="c9bce220" sha1="4245d6ce4ba9cd28f67a4872ebc375c17fe4974b" offset="0" />
@@ -757,7 +757,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4013" />
 		<info name="usage" value="3 or 4 player gameplay available only on 400/800 systems" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="asteroids.rom" size="8192" crc="f9fff4a4" sha1="71b795834e575e17bf1deb259fc699315218454c" offset="0" /> <!-- Verified -->
@@ -772,7 +772,7 @@ Compiled by K1W1
 		<publisher>Exidy</publisher>
 		<info name="developer" value="First Star" />
 		<sharedfeat name="compatibility" value="XL"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="astro chase (first star software)(1982).rom" size="16384" crc="18752991" sha1="f508b89d2251c53d017cff6cb23b8e9880a0cc0b" offset="0" /> <!-- Verified -->
@@ -787,7 +787,7 @@ Compiled by K1W1
 		<info name="developer" value="First Star" />
 		<info name="serial" value="1190" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="astro chase (parker brothers)(1983).rom" size="16384" crc="11f1c7fa" sha1="36cca84a113e3adf6759a7c71df30cbed16924f2" offset="0" /> <!-- Verified -->
@@ -801,7 +801,7 @@ Compiled by K1W1
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0502" />
 		<info name="usage" value="Keyboard overlay was supplied with cartridge" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="astro grover.rom" size="16384" crc="85b67797" sha1="b7d9eef4516457fa6301bff1e436ea1f5860956b" offset="0" /> <!-- Verified -->
@@ -814,7 +814,7 @@ Compiled by K1W1
 		<year>1986</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8002" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="atari basic programming language (revision c).rom" size="8192" crc="7d684184" sha1="3693c9cb9bf3b41bae1150f7a8264992468fc8c0" offset="0" /> <!-- Verified -->
@@ -827,7 +827,7 @@ Compiled by K1W1
 		<!-- Never released in cartridge form. Only built into Atari XL series. -->
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="atari basic programming language (revision b).rom" size="8192" crc="f0202fb3" sha1="7ad88dd99ff4a6ee66f6d162074db6f8bef7a9b6" offset="0" /> <!-- Verified -->
@@ -840,7 +840,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4002" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="atari basic programming language (revision a).rom" size="8192" crc="4bec4de2" sha1="70cdf57469a208528f78a14275837352e90e20f1" offset="0" /> <!-- Verified -->
@@ -853,7 +853,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8032" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atari logo computing language.rom" size="16384" crc="9663db9d" sha1="b772587d9322adbdb995c96ac9f4fccd8316750f" offset="0" /> <!-- Verified -->
@@ -866,7 +866,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RXF80??" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atari logo (france).rom" size="16384" crc="242d5e2d" sha1="f19feb03c3f936cd999eacb23806008034e33962" offset="0" />
@@ -879,7 +879,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8035" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="microsoft basic ii programming language.rom" size="16384" crc="24391ffb" sha1="9f0ee797e07bbc74d5d7b664157a80019634172d" offset="0" /> <!-- Verified -->
@@ -898,7 +898,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8053" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="peripheral" value="cx77_touch" /> <!-- Uses the Atari CX77 touch tablet device -->
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
@@ -912,7 +912,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8084" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atariwriter (rev. c).rom" size="16384" crc="b4ddbec7" sha1="3b6ced3aeb08dafeac0b8c7f22d3c8b1aa6eebde" offset="0" /> <!-- Verified -->
@@ -925,7 +925,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8084" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atariwriter (rev. b).rom" size="16384" crc="7be4533d" sha1="69a842a3b89e3f4780f3266262a4dabb57b2afb0" offset="0" /> <!-- Verified -->
@@ -941,7 +941,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8084" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atariwriter (rev. a).rom" size="16384" crc="1c2498a4" sha1="a13863ad3ec72a92744b6e4d0e6c17faf51d17a8" offset="0" /> <!-- Verified -->
@@ -954,7 +954,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RXF8036" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ataritexte" size="16384" crc="2aff4a94" sha1="db1198a5f7e03012d99a1bc9560316059f1c1c6a" offset="0" /> <!-- Verified -->
@@ -967,7 +967,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RXF8036" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ataritexte (proto).rom" size="16384" crc="fabaf286" sha1="9f552aeafdcb4a1feb89df8ae391f2fea1306de9" offset="0" />
@@ -980,7 +980,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RXG8036" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="atarischreiber.rom" size="16384" crc="de1c1d12" sha1="8c0f7be263e3c30bcf34adf3dddee15d62ac62cc" offset="0" />
@@ -993,7 +993,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Imagic</publisher>
 		<info name="serial" value="720125-1A" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="atlantis.rom" size="8192" crc="f929f40f" sha1="c795029c69b7b88efad659e107cad415ff3e066e" offset="0" /> <!-- Verified -->
@@ -1006,7 +1006,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Romox</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="attack at ep-cyg-4.rom" size="16384" crc="dca02ca0" sha1="78d394217f9ad68907e7dd86464b02f751c2321b" offset="0" /> <!-- Verified -->
@@ -1019,7 +1019,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>HES</publisher>
 		<info name="serial" value="C518" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="attack of the mutant camels.rom" size="8192" crc="c933d741" sha1="06f4e357fe449be546d7059b22500a47b7c47798" offset="0" /> <!-- Verified -->
@@ -1032,7 +1032,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8054" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<feature name="peripheral" value="cx75_pen" /> <!-- Uses the Atari CX75 light pen device -->
 			<dataarea name="rom" size="16384">
@@ -1046,7 +1046,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>InHome</publisher>
 		<info name="serial" value="BR1001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="baseball.rom" size="16384" crc="43c9d2a0" sha1="3f811800d2c616602d809b4d5496b64a0fc27972" offset="0" /> <!-- Verified -->
@@ -1059,7 +1059,7 @@ Compiled by K1W1
 		<year>1986</year>
 		<publisher>OSS</publisher>
 		<sharedfeat name="compatibility" value="XL/XE"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="basic xe programming language v7.2.rom" size="16384" crc="3f06b111" sha1="ac80e12fcd7e228e0329ba1a2f3408b37af0b7ff" offset="0" />
@@ -1078,7 +1078,7 @@ Compiled by K1W1
 		<year>1985</year>
 		<publisher>OSS</publisher>
 		<sharedfeat name="compatibility" value="XL/XE"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="basic xe programming language v4.1.rom" size="16384" crc="003d3a36" sha1="76f06d212c5f972f9540bee26b23ecc010f3b535" offset="0" /> <!-- Verified -->
@@ -1090,7 +1090,7 @@ Compiled by K1W1
 		<description>Basic XL Programming Language v1.03</description>
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="basic xl programming language v1.03.rom" size="16384" crc="94a05568" sha1="01eefc1ed8625cf264a00b15acd6c3698cebfdcc" offset="0" /> <!-- Verified -->
@@ -1103,7 +1103,7 @@ Compiled by K1W1
 		<description>Basic XL Programming Language v1.02</description>
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss034m" />
 			<dataarea name="rom" size="16384">
 				<rom name="basic xl programming language v1.02.rom" size="16384" crc="e8b3fc3c" sha1="d43bea60d15aa7ad41e074396dfe5019e8415353" offset="0" /> <!-- Verified -->
@@ -1116,7 +1116,7 @@ Compiled by K1W1
 		<!-- Different cartridge mapping. -->
 		<year>1983</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss043m" />
 			<dataarea name="rom" size="16384">
 				<rom name="basic xl programming language v1.02 (alt).rom" size="16384" crc="5752d29f" sha1="787402aa14379f70e5102a066473a0bdd490d834" offset="0" /> <!-- Verified -->
@@ -1130,7 +1130,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4004" />
 		<info name="usage" value="3 or 4 player gameplay available only on 400/800 systems" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="basketball.rom" size="8192" crc="1ba8d718" sha1="c6b2f72fdae8be916fe408a208727a18e19b8a0d" offset="0" /> <!-- Verified -->
@@ -1143,7 +1143,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="OTL-201" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="bc's quest for tires.rom" size="16384" crc="dddc6e36" sha1="c28f029ac5a388d791f22344ea078ed18660be4b" offset="0" /> <!-- Verified -->
@@ -1156,7 +1156,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CA-009-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="beamrider.rom" size="16384" crc="2b05b8df" sha1="836b957e769632aace671a457fc07b7d0be1ca3a" offset="0" /> <!-- Verified -->
@@ -1172,7 +1172,7 @@ Compiled by K1W1
 		<info name="serial" value="10031A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="bearjam (fixed).rom" size="8192" crc="1889c707" sha1="f6df83d8ef0410edd2eb177d503fe8e0e0be908f" offset="0" />
@@ -1184,7 +1184,7 @@ Compiled by K1W1
 		<description>Berzerk (Prototype)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="berzerk (proto).rom" size="16384" crc="b1dedb79" sha1="4add13e98bede206555390349b5f24a93049f0be" offset="0" />
@@ -1198,7 +1198,7 @@ Compiled by K1W1
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0505" />
 		<info name="usage" value="Keyboard overlay was supplied with cartridge" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="big bird's funhouse.rom" size="16384" crc="9fd095e0" sha1="f2bc6a83a31d8f1224026365558123ce5c9ef261" offset="0" /> <!-- Verified -->
@@ -1211,7 +1211,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0109" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="big bird's special delivery.rom" size="16384" crc="6d93b4fa" sha1="d8167ee465116425c6bd9ad254b2ba96844d000e" offset="0" /> <!-- Verified -->
@@ -1223,7 +1223,7 @@ Compiled by K1W1
 		<description>Blaster (Prototype)</description>
 		<year>1984</year>
 		<publisher>Williams</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="blaster (proto).rom" size="16384" crc="ce1126a2" sha1="02eb5907b9e668ce57b7e561a146224728f01cb8" offset="0" />
@@ -1236,7 +1236,7 @@ Compiled by K1W1
 		<year>2009</year>
 		<publisher>GR8 Software</publisher>
 		<info name="usage" value="Plays music only in PAL" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_corina" />
 			<dataarea name="rom" size="532480">
 				<rom name="bomb jake.rom" size="532480" crc="8e89ca50" sha1="b3bca012eb2207e97dffcd5946b163b8a6f50d71" offset="0" />
@@ -1249,7 +1249,7 @@ Compiled by K1W1
 		<!-- Also released on the Exidy Max-a-Flex arcade cabinet. -->
 		<year>1984</year>
 		<publisher>First Star</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="boulder dash.rom" size="16384" crc="af778329" sha1="151d12b58c30880a3640dffc5b1d67de790c0099" offset="0" /> <!-- Verified -->
@@ -1262,7 +1262,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-2540" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="boulders and bombs.rom" size="8192" crc="d6d51d3e" sha1="90901cd874f4ece8e18d9fff63e2368b4a315624" offset="0" /> <!-- Verified -->
@@ -1274,7 +1274,7 @@ Compiled by K1W1
 		<description>Bounty Bob Strikes Back!</description>
 		<year>1984</year>
 		<publisher>Big Five Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_bbsb" />
 			<dataarea name="rom" size="40960">
 				<rom name="bounty bob strikes back!.rom" size="40960" crc="cc7912ed" sha1="5a064551c22a267879c69b7cc97ea3c67f21b851" offset="0" /> <!-- Verified -->
@@ -1287,7 +1287,7 @@ Compiled by K1W1
 			<!-- Identical to the image contained in Bill Hogue's emulator. http://www.bigfivesoftware.com/Emulator/emulator.htm. -->
 		<year>1984</year>
 		<publisher>Big Five Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_bbsb" />
 			<dataarea name="rom" size="40960">
 				<rom name="bounty bob strikes back! (alt).rom" size="40960" crc="0d00f072" sha1="57e3856b6b00e94490350156620dc61cf0669c17" offset="0" />
@@ -1300,7 +1300,7 @@ Compiled by K1W1
 		<!-- Also released on the Exidy Max-a-Flex arcade cabinet. -->
 		<year>1983</year>
 		<publisher>First Star</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="bristles.rom" size="16384" crc="4263d64d" sha1="80a041bceb499e1466516488013aa4439b3db6f2" offset="0" /> <!-- Verified -->
@@ -1313,7 +1313,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="005-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="buck rogers - planet of zoom.rom" size="16384" crc="84dd597c" sha1="cfea37ea951fede973faccba882afc7b64d02fcb" offset="0" /> <!-- Verified -->
@@ -1326,7 +1326,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>InHome</publisher>
 		<info name="serial" value="CR1002" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="captain beeble.rom" size="16384" crc="ad8400b1" sha1="bee1157a64578b1b714f17c644db5af2ac6980c9" offset="0" /> <!-- Verified -->
@@ -1340,7 +1340,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12011" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="carnival massacre.rom" size="16384" crc="0c8e8d5b" sha1="a3540dc84fbc1562eed92af22ea4407148bc9790" offset="0" />
@@ -1354,7 +1354,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12011" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="carnival massacre (earlier version).rom " size="16384" crc="ea764851" sha1="41ee0cfcc3dd9fc850bb9639a12674774966160e" offset="0" /> <!-- Verified -->
@@ -1367,7 +1367,7 @@ Compiled by K1W1
 		<year>199?</year>
 		<publisher>&lt;unknown&gt;</publisher>
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="turbo blizzard.bin" size="16384" crc="318ed507" sha1="ad2adde7decaa2e40bc0dcb8db0d6d8977a5af22" offset="0" />
@@ -1381,7 +1381,7 @@ Compiled by K1W1
 		<publisher>Info-Cell</publisher>
 		<info name="developer" value="Pawel Mironczuk" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="cartridge turbo 2000 v3.16.bin" size="16384" crc="f25da498" sha1="5b36306165a221930ac9e9fdc46396714b93224c" offset="0" />
@@ -1395,7 +1395,7 @@ Compiled by K1W1
 		<publisher>DOMAIN SOFT</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="cartridge dla turbo 2000 v1.0.rom" size="16384" crc="c848a61c" sha1="357d3a825c8c7b3c01257db02dd6210a1de7f624" offset="0" />
@@ -1409,7 +1409,7 @@ Compiled by K1W1
 		<publisher>DOMAIN SOFT</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="cartridge dla turbo 2000 v1.0 (a).rom" size="16384" crc="9ca5d00d" sha1="9a545bbdab0edb1fc42a052e08a90db3617fc602" offset="0" />
@@ -1423,7 +1423,7 @@ Compiled by K1W1
 		<publisher>ROBOsoft</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="cartridge turbo 2000 (v.1).rom" size="16384" crc="60787a1a" sha1="5dfead5e2fa59d22d795f5c544adb5007dd5dbee" offset="0" />
@@ -1437,7 +1437,7 @@ Compiled by K1W1
 		<publisher>ROBOsoft</publisher>
 		<info name="developer" value="Tomasz Rolewski" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="cartridge turbo 2000 (v.2).rom" size="16384" crc="45a8b12e" sha1="7a85f67ff2c491d900ea1b8afd2cdef42f99ac81" offset="0" />
@@ -1451,7 +1451,7 @@ Compiled by K1W1
 		<publisher>JK Soft</publisher>
 		<info name="developer" value="Bartek Selinger" />
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="jk soft cartridge system turbo 2000.rom" size="16384" crc="a407eef0" sha1="d856cc5e2ab4f7eb5c2baa447480bcdf2af05620" offset="0" />
@@ -1464,7 +1464,7 @@ Compiled by K1W1
 		<year>1991</year>
 		<publisher>Bartek Selinger</publisher>
 		<info name="usage" value="Requires Lower-Silesian Turbo 2000 hardware modification installed in a tape recorder." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="selinger cartridge system turbo 2000.rom" size="16384" crc="f80b8c8c" sha1="ecc35ccf7ac95a70799a905d2a3238331a9bb02f" offset="0" />
@@ -1477,7 +1477,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01123" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="castle hassle.rom" size="16384" crc="5a9e938a" sha1="964769d2fbb1092f06247e71fa8f1b86fb01b33c" offset="0" /> <!-- Verified -->
@@ -1490,7 +1490,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Romox</publisher>
 		<info name="serial" value="ECPC-13023" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="castles and keys.rom" size="16384" crc="be14c091" sha1="adbf3f7c5be41ae395ecca6a57fe8f2941061d2c" offset="0" />
@@ -1504,7 +1504,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8021" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="caverns of mars.rom" size="16384" crc="8b9b2f5e" sha1="08b05c7a118530c9e3ac79eaef9514422b1bb5dc" offset="0" /> <!-- Verified -->
@@ -1518,7 +1518,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4020" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="centipede.rom" size="8192" crc="44bb1842" sha1="2eed9a6bbc4c0396a0efc48fc810f9363c23a3c3" offset="0" /> <!-- Verified -->
@@ -1530,7 +1530,7 @@ Compiled by K1W1
 		<description>Centipede (Prototype)</description>
 		<year>1981</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="centipede (proto).rom" size="8192" crc="d54f0200" sha1="cece5a5023ea666826e538d2f02a599d241aeb57" offset="0" />
@@ -1546,7 +1546,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL8001" />
 		<info name="usage" value="Requires a special boot disk, currently unavailable." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="checkbook (proto).rom" size="8192" crc="d12471b7" sha1="b3783e60bae8c9287a755d39e47d75963539c82c" offset="0" />
@@ -1559,7 +1559,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1100" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="chess.rom" size="8192" crc="72860db1" sha1="0502b3946c80e064f46a607fc4df0a2977e8761f" offset="0" /> <!-- Verified -->
@@ -1572,7 +1572,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="chicken.rom" size="8192" crc="1ab4d8d8" sha1="ca13ce6116370cae7b464b53393ac801c6914a90" offset="0" /> <!-- Verified -->
@@ -1585,7 +1585,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari France</publisher>
 		<info name="serial" value="RXF52001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="chiffres et des lettres, des.rom" size="16384" crc="c7705c53" sha1="fd45a75178dbe2426373bf720639160ed91d892a" offset="0" />
@@ -1599,7 +1599,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari France</publisher>
 		<info name="serial" value="RXF52001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="chiffres et des lettres, des (alt).rom" size="16384" crc="3d8f5c25" sha1="51c490b284e44923943b2327550e3e40e7bcc6c5" offset="0" /> <!-- Verified -->
@@ -1612,7 +1612,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Brøderbund</publisher>
 		<info name="serial" value="ATCART191" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="choplifter!.rom" size="16384" crc="3ebc05ff" sha1="a8a28c18e249272c27f7d72f7c40dab2e8d712f2" offset="0" /> <!-- Verified -->
@@ -1624,7 +1624,7 @@ Compiled by K1W1
 		<description>Claim Jumper</description>
 		<year>1982</year>
 		<publisher>Synapse</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="claim jumper.rom" size="16384" crc="374d14d9" sha1="fc5993fbe43683239268c6e40cea8bec6457908e" offset="0" /> <!-- Verified -->
@@ -1636,7 +1636,7 @@ Compiled by K1W1
 		<description>Cloudburst</description>
 		<year>1982</year>
 		<publisher>DANA</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="cloudburst.rom" size="8192" crc="32e5629e" sha1="56f2ec0ee4fd2f2c7532cd6a792a0a193cb5e91d" offset="0" /> <!-- Verified -->
@@ -1649,7 +1649,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9847" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="coconotes.rom" size="16384" crc="f93c615b" sha1="d70ef079097293256a9b0d2bb34f8b8a49eac565" offset="0" /> <!-- Verified -->
@@ -1662,7 +1662,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4009" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="computer chess.rom" size="8192" crc="c9614423" sha1="dc3c2ab6736546975de16282c44b4b445c312ff6" offset="0" /> <!-- Verified -->
@@ -1676,7 +1676,7 @@ Compiled by K1W1
 		<year>1987</year>
 		<publisher>Compu=Prompt, Inc.</publisher>
 		<info name="serial" value="25078" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="compu=prompt.rom" size="8192" crc="58ccf059" sha1="e749d8fb1f48ce61eb191382aa0a2ffdc03ad57e" offset="0" />
@@ -1689,7 +1689,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="FD100335" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="supersalt.rom" size="16384" crc="0d99e328" sha1="ebf55b9721ba69303bb53de9e580c28a11f7c9be" offset="0" /> <!-- Verified -->
@@ -1704,7 +1704,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Computrac</publisher>
 		<info name="developer" value="IDSI" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="computrac 4000-8000.rom" size="16384" crc="e88a2ea3" sha1="11a17a51cd9be533debeddef8841effdfea8d591" offset="0" />
@@ -1717,7 +1717,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THA12010" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="computer war.rom" size="16384" crc="4922aac6" sha1="d4fa88f4f8dd3b2c7fac3c6f57fe6ccff4075108" offset="0" /> <!-- Verified -->
@@ -1730,7 +1730,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="006-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="congo bongo.rom" size="16384" crc="7a588045" sha1="64c0a80e7dc289a62669e6e770f0d2b622b01036" offset="0" /> <!-- Verified -->
@@ -1742,7 +1742,7 @@ Compiled by K1W1
 		<description>Conquest of the Crown</description>
 		<year>1994</year>
 		<publisher>Lindasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="conquest of the crown.rom" size="16384" crc="94f56b90" sha1="855e5ef9a17fdeb0a1250cb3e88865af7fbca0b7" offset="0" />
@@ -1755,7 +1755,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="COS-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="cosmic life.rom" size="8192" crc="ec65758b" sha1="7c98acfb21cbc8059951c66893f4b077e8cb324c" offset="0" /> <!-- Verified -->
@@ -1767,7 +1767,7 @@ Compiled by K1W1
 		<description>Cosmic Tunnels (Prototype)</description>
 		<year>1983</year>
 		<publisher>Datamost</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="cosmic tunnels (proto).rom" size="16384" crc="ad56c2bf" sha1="8ef473276b88049666c88c36f465a54cd98a2484" offset="0" />
@@ -1780,7 +1780,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="CFL-202" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="crossfire.rom" size="8192" crc="4d7e0503" sha1="f307396c6230d79275f0a3d8898eca84c8b97209" offset="0" /> <!-- Verified -->
@@ -1792,7 +1792,7 @@ Compiled by K1W1
 		<description>Crystal Castles (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="crystal castles (proto).rom" size="16384" crc="6c64892c" sha1="d9f7a3185c17655ef3cfb848a13d2f1090b565e7" offset="0" />
@@ -1805,7 +1805,7 @@ Compiled by K1W1
 		<!-- Re-package & Re-release of Mastertronic 1986 release. -->
 		<year>2001</year>
 		<publisher>Video 61 / Mastertronic</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="crystal raider.rom" size="16384" crc="f15b2306" sha1="e89d07dd7f00a234dfab05440cd972ea8e7c0aa6" offset="0" />
@@ -1817,7 +1817,7 @@ Compiled by K1W1
 		<description>Da' Fuzz</description>
 		<year>1983</year>
 		<publisher>Roklan</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="da' fuzz.rom" size="8192" crc="bcda6dba" sha1="053c651894843f432a3555a47ca3bba06584163d" offset="0" />
@@ -1830,7 +1830,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Microdeal</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="danger ranger.rom" size="8192" crc="f5497ef3" sha1="1d0fbda42d4166f8b08d7c1a9b1ffc5baf982777" offset="0" />
@@ -1843,7 +1843,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Fisher-Price</publisher>
 		<info name="serial" value="DCF-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="dance fantasy.rom" size="8192" crc="faec94e7" sha1="85e64f5d599b8c9a69d2e4cdb09535731897bca9" offset="0" /> <!-- Verified -->
@@ -1856,7 +1856,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CC-008-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="decathlon.rom" size="16384" crc="affbe54b" sha1="7a6e2761f9ba1983c2b76f71ca08ae097691617f" offset="0" /> <!-- Verified -->
@@ -1870,7 +1870,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4025" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="defender.rom" size="16384" crc="782a81e4" sha1="eda6e6b875a76176384e356e7b9ded3bb7699ba2" offset="0" /> <!-- Verified -->
@@ -1883,7 +1883,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="DLD-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="delta drawing - learning program.rom" size="8192" crc="20cbad07" sha1="ca9165d3ce9b77cc7e6f099ff24b0db0bec19c71" offset="0" /> <!-- Verified -->
@@ -1896,7 +1896,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01101" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="deluxe invaders.rom" size="8192" crc="15dc9b31" sha1="c168b06d66afc07f0f49d21bc3e52ddf02ee5c91" offset="0" /> <!-- Verified -->
@@ -1910,7 +1910,7 @@ Compiled by K1W1
 		<publisher>Imagic</publisher>
 		<info name="serial" value="720149-1A" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="demon attack.rom" size="8192" crc="1cb8b52d" sha1="5b279412afd8338622c33ff7f5e1a64d0b41c247" offset="0" /> <!-- Verified -->
@@ -1922,7 +1922,7 @@ Compiled by K1W1
 		<description>Destiny: The Cruiser (Prototype)</description>
 		<year>198?</year>
 		<publisher>Adventure International</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="destiny - the cruiser (proto).rom" size="16384" crc="0c847bb3" sha1="42ce8d92159e798f74ec9816017c464339f719a1" offset="0" />
@@ -1935,7 +1935,7 @@ Compiled by K1W1
 		<!-- This file was released by the developer to the public domain with the file name "diamond2.rom". He explained in a Usenet post that it is in fact version 3. -->
 		<year>1989</year>
 		<publisher>Reeve Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_diamond" />
 			<dataarea name="rom" size="65536">
 				<rom name="diamond gos v3.0.rom" size="65536" crc="0ead07f8" sha1="e9203742580d50aba99bb85d8f04816ac76df730" offset="0" />
@@ -1962,7 +1962,7 @@ Compiled by K1W1
 		<description>Diamond Graphic OS v1.0</description>
 		<year>1989</year>
 		<publisher>Reeve Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_diamond" />
 			<dataarea name="rom" size="65536">
 				<rom name="diamond gos v1.0.(1989)rom" size="65536" crc="ff169415" sha1="d8335378562e67c422fab783f11074db8d401161" offset="0" />
@@ -1974,7 +1974,7 @@ Compiled by K1W1
 		<description>Diamond Graphic OS v1.0 (Earlier Release)</description>
 		<year>1988</year>
 		<publisher>Reeve Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_diamond" />
 			<dataarea name="rom" size="65536">
 				<rom name="diamond gos 1.0 (1988).rom" size="65536" crc="cdeb2c5c" sha1="d55c0993b963f4031525e411cb1da6e282030bad" offset="0" />
@@ -1987,7 +1987,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01131" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="diamond mine.rom" size="16384" crc="d8f9b867" sha1="1a88faf57a90ee5a69f9a1bdcc98ec436b38b867" offset="0" /> <!-- Verified -->
@@ -2001,7 +2001,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8026" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="dig dug.rom" size="16384" crc="fdbc57ed" sha1="cbdf46cb6bc168a3473e3f5b958c22059080e11c" offset="0" /> <!-- Verified -->
@@ -2014,7 +2014,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8026" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="dig dug (earlier release).rom" size="16384" crc="6d68114e" sha1="de7ff90bb9c2b9f890a2cc8d3bb54766d6103684" offset="0" /> <!-- Verified -->
@@ -2028,7 +2028,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8031" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="donkey kong.rom" size="16384" crc="8a406275" sha1="6f5c069ff6b156a1dc4a4b64c4fad12eec70244a" offset="0" /> <!-- Verified -->
@@ -2042,7 +2042,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8040" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="donkey kong jr.rom" size="16384" crc="a3e2d833" sha1="f6d917daf916683a4785792c72d30a914769846a" offset="0" /> <!-- Verified -->
@@ -2054,7 +2054,7 @@ Compiled by K1W1
 		<description>Direct Access</description>
 		<year>1984</year>
 		<publisher>Citibank</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="direct access.rom" size="16384" crc="0b5c7bd3" sha1="0030ed9f16ab9b5a8e547b914c8dc28960dc1eaa" offset="0" />
@@ -2067,7 +2067,7 @@ Compiled by K1W1
 		<!-- Cartridge dated 12/24/84. -->
 		<year>1984</year>
 		<publisher>Citibank</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="direct access (a).rom" size="16384" crc="bbdabfcb" sha1="b57b6f5bd41a3e075d242504d27e7ff4b162ea98" offset="0" />
@@ -2079,7 +2079,7 @@ Compiled by K1W1
 		<description>Droids</description>
 		<year>1983</year>
 		<publisher>TG Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="droids.rom" size="8192" crc="5bb0c159" sha1="d9e67e21e777598c5e18587ba9d6f2beecec0f4f" offset="0" /> <!-- Verified -->
@@ -2092,7 +2092,7 @@ Compiled by K1W1
 		<year>20??</year>
 		<publisher>Video 61</publisher>
 		<info name="developer" value="Williams" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="drop zone.rom" size="65536" crc="4870ed52" sha1="4393f93b1fcff7dfb34bb5cf4f745a70b56159e2" offset="0" />
@@ -2105,7 +2105,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9889" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ducks ahoy!.rom" size="16384" crc="4cdfceb9" sha1="e2bb6270e2646b9c721c4c038c0fddfccf7218a4" offset="0" /> <!-- Verified -->
@@ -2118,7 +2118,7 @@ Compiled by K1W1
 		<!-- Re-package & Re-release of GMG's 1997 release. -->
 		<year>1999</year>
 		<publisher>Video 61 / GMG</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="dynakillers.rom" size="65536" crc="ad050724" sha1="cdb1dfbeb6b634e1d359e749a68821da0ab83950" offset="0" />
@@ -2131,7 +2131,7 @@ Compiled by K1W1
 		<year>198?</year>
 		<publisher>LJK</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="edit6502.rom" size="8192" crc="7595ea16" sha1="cd393690154e43d6771956729ff3f9af914cd19b" offset="0" />
@@ -2144,7 +2144,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8030" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="e.t. phone home!.rom" size="16384" crc="bce4ef51" sha1="c4a10ce59ee183ef4299e50a0825ec23b4315b56" offset="0" /> <!-- Verified -->
@@ -2158,7 +2158,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8039" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="eastern front - 1941.rom" size="16384" crc="ccff4a03" sha1="aee71f33534cf566994358a909b4b2dca63a84f1" offset="0" /> <!-- Verified -->
@@ -2171,7 +2171,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="educational system master cartridge.rom" size="8192" crc="baacbad4" sha1="15567104105e91aeffc704158d7a4d1143ccd9b3" offset="0" /> <!-- Verified -->
@@ -2184,7 +2184,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Dorsett Educational Systems</publisher>
 		<info name="serial" value="D4001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="educational system master cartridge (dorsett).rom" size="8192" crc="df830b2e" sha1="09cd7307e76c11c1def3613879bdf74576f73843" offset="0" />
@@ -2196,7 +2196,7 @@ Compiled by K1W1
 		<description>Embargo</description>
 		<year>1982</year>
 		<publisher>Gebelli Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="embargo.rom" size="8192" crc="07b1560c" sha1="464a127b9abb0700a34eb5068ef5c7a1c858e238" offset="0" /> <!-- Verified -->
@@ -2209,7 +2209,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0108" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ernie's magic shapes.rom" size="16384" crc="435f5aba" sha1="05b935e0a1cae9b72fad28e7ec0b443080ede57a" offset="0" /> <!-- Verified -->
@@ -2222,7 +2222,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Tigervision</publisher>
 		<info name="serial" value="7-012-468" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="espial.rom" size="16384" crc="dcde7482" sha1="2e91cbe5a17ce1bddf5745691e5bf4ed29564979" offset="0" />
@@ -2234,7 +2234,7 @@ Compiled by K1W1
 		<description>Excelsor (Pirate)</description>
 		<year>1986</year>
 		<publisher>Players</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="excelsor.rom" size="8192" crc="a854cc63" sha1="d887c2be7cc1c9a704b8f800dea7f1ef03fabe3a" offset="0" />
@@ -2247,7 +2247,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Stimultech</publisher>
 		<info name="usage" value="Expando-Vision hardware device required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="expando-vision 1 - weight control and exercise.rom" size="8192" crc="1b5848c0" sha1="929d9d2d7f523e0a3bb86bb08d90905e60fd4e0b" offset="0" />
@@ -2260,7 +2260,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Stimultech</publisher>
 		<info name="usage" value="Expando-Vision hardware device required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="expando-vision 2 - control smoking and calm nerves.rom" size="8192" crc="eb8b49b9" sha1="662613be02f401407686c11e5653c460487cb9c4" offset="0" />
@@ -2273,7 +2273,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Stimultech</publisher>
 		<info name="usage" value="Expando-Vision hardware device required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="expando-vision 3 - stress control and positive thinking.rom" size="8192" crc="b68b0a9b" sha1="5095dc591f7209e55c4d754110f427d23a1abb10" offset="0" />
@@ -2286,7 +2286,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Stimultech</publisher>
 		<info name="usage" value="Expando-Vision hardware device required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="expando-vision 4 - control drinking and responsibility.rom" size="8192" crc="2343acf3" sha1="1cea338dabfbf22ec9be0a76796e3fee6d4e78b6" offset="0" />
@@ -2299,7 +2299,7 @@ Compiled by K1W1
 		<year>1989</year>
 		<publisher>Orion Micro Systems</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_express" />
 			<dataarea name="rom" size="65536">
 				<rom name="express! v1.12.rom" size="65536" crc="4a5fcefd" sha1="5ed02fc71cdc1ba661120e873fcf58feade78d7a" offset="0" />
@@ -2312,7 +2312,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="FMK-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="facemaker.rom" size="8192" crc="382d859e" sha1="e1dae8e5b6b5cac1745e7ccacd1f5b7530276fd8" offset="0" /> <!-- Verified -->
@@ -2325,7 +2325,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33008" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="fantastic voyage.rom" size="8192" crc="cd428e17" sha1="88edeb54c1afa5831802b2f509c88bb76d9235d0" offset="0" /> <!-- Verified -->
@@ -2338,7 +2338,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33003" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="fast eddie.rom" size="8192" crc="0939f2d0" sha1="a2b42976d6c807f6977a5e91e19b2fd1abe76066" offset="0" /> <!-- Verified -->
@@ -2351,7 +2351,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8067" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="final legacy (text menu version).rom" size="16384" crc="6bd0d8e4" sha1="4bdfbab83e336c58e4cc2e3dbb096f29976f5761" offset="0" /> <!-- Verified -->
@@ -2364,7 +2364,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8067" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="final legacy (graphic menu version).rom" size="16384" crc="506e4ed0" sha1="e123d4b3a32cf49c7907ae945ff9c98dbc945458" offset="0" />
@@ -2377,7 +2377,7 @@ Compiled by K1W1
 		<!-- Name changed to 'Final Legacy' on release. -->
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="the legacy (proto).rom" size="16384" crc="a445af7d" sha1="a2c5549a924e0d8130ce3f3299af37e430d8b8c9" offset="0" />
@@ -2390,7 +2390,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sirius</publisher>
 			<info name="serial" value="3300?" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="final orbit.rom" size="8192" crc="4de5cd53" sha1="0bfa27e1e588d15c6fdfea1a3bb2c9c610234eea" offset="0" /> <!-- Verified -->
@@ -2402,7 +2402,7 @@ Compiled by K1W1
 		<description>Firebird</description>
 		<year>1981</year>
 		<publisher>Gebelli Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="firebird.rom" size="8192" crc="b9557f4b" sha1="109556634f015a993501dd2c3889065127f408b1" offset="0" />
@@ -2415,7 +2415,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Romox</publisher>
 		<info name="serial" value="ECPC-11023" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="flapper.rom" size="16384" crc="18803c52" sha1="b4de4bb49d566db4609b3a279288991ad2cca9ce" offset="0" />
@@ -2428,7 +2428,7 @@ Compiled by K1W1
 		<!-- Also released on the Exidy Max-a-Flex arcade cabinet. -->
 		<year>1983</year>
 		<publisher>First Star</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="flip and flop.rom" size="16384" crc="8ae057be" sha1="ba26d6a3790ebdb754c1192b2c28f0fe93aca377" offset="0" /> <!-- Verified -->
@@ -2441,7 +2441,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="fort apocalypse.rom" size="16384" crc="f79b33f0" sha1="cd3b8efa5d1b0960961c566eec63be3ff399885d" offset="0" /> <!-- Verified -->
@@ -2453,7 +2453,7 @@ Compiled by K1W1
 		<description>Fortune Hunter</description>
 		<year>1982</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="fortune hunter.rom" size="8192" crc="5cee3180" sha1="5ea0655ff8fcdb2f0db41831fb0781b53541036f" offset="0" /> <!-- Verified -->
@@ -2466,7 +2466,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="FRF-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="fraction fever.rom" size="8192" crc="6f439f87" sha1="e2f9baa6fef628593e8287dbc2dba01292d24c72" offset="0" /> <!-- Verified -->
@@ -2479,7 +2479,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1110" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="frogger.rom" size="8192" crc="40e9476c" sha1="a4863c26c9e6752211684c9efe10b86c1650314a" offset="0" /> <!-- Verified -->
@@ -2492,7 +2492,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1290" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="frogger ii - threedeep!.rom" size="16384" crc="7a5b4f65" sha1="a70678dbc4f00059faeff8f15896c535730256cb" offset="0" /> <!-- Verified -->
@@ -2504,7 +2504,7 @@ Compiled by K1W1
 		<description>Fun with Art</description>
 		<year>1983</year>
 		<publisher>Epyx</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="fun with art.rom" size="16384" crc="db730551" sha1="9a34791b1937bc3cb680b91d75b29162f80448e8" offset="0" /> <!-- Verified -->
@@ -2518,7 +2518,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4024" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="galaxian.rom" size="8192" crc="d60027be" sha1="aa54b46b90d3f5d639dcb63f0e629803dbd369e2" offset="0" /> <!-- Verified -->
@@ -2531,7 +2531,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="614R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="gateway to apshai.rom" size="16384" crc="4ccdbef0" sha1="4214638ed6a7ea3409b96dcfb3210617f05c441b" offset="0" /> <!-- Verified -->
@@ -2544,7 +2544,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>SpectraVideo</publisher>
 		<info name="serial" value="SB-214" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="gold mine.rom" size="8192" crc="8459b11e" sha1="5a1e44ac64205c08ce6037facb0b1b428c1e3115" offset="0" /> <!-- Verified -->
@@ -2559,7 +2559,7 @@ Compiled by K1W1
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01102" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="gorf.rom" size="8192" crc="90d0c7d7" sha1="15b20d50c70c383b84060efc7bb5149b1de73b3b" offset="0" /> <!-- Verified -->
@@ -2572,7 +2572,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>HES</publisher>
 		<info name="serial" value="C712" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="gridrunner.rom" size="8192" crc="02f44555" sha1="04490bb51662713913087fbc33af507b56ca80dd" offset="0" /> <!-- Verified -->
@@ -2585,7 +2585,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1280" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="gyruss.rom" size="16384" crc="1da47d01" sha1="865f06d66c4749d4bb12f2100f5b14a1aeeb9113" offset="0" /> <!-- Verified -->
@@ -2598,7 +2598,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-007-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="hero.rom" size="16384" crc="6062d3ce" sha1="24986c3cb59b0f9324929be3173eccd694445aa6" offset="0" /> <!-- Verified -->
@@ -2611,7 +2611,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9848" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="halftime battlin' bands.rom" size="16384" crc="8d14b5d3" sha1="ed8f805bdc947f1d9590db1e098f9f77f413f9db" offset="0" /> <!-- Verified -->
@@ -2623,7 +2623,7 @@ Compiled by K1W1
 		<description>Hard Hat Willy</description>
 		<year>1983</year>
 		<publisher>InHome</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="hard hat willy.rom" size="16384" crc="214be698" sha1="87f520255589db693a8e6cbf93a252212b32a435" offset="0" />
@@ -2636,7 +2636,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Kantronics</publisher>
 		<info name="usage" value="Kantronics interface II required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="hamsoft - amtor v1.2.rom" size="8192" crc="e9ba99a6" sha1="11accca3ea77160108f91dd12c412966b7539e7f" offset="0" />
@@ -2649,7 +2649,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Kantronics</publisher>
 		<info name="usage" value="Kantronics interface II required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="hamsoft.rom" size="8192" crc="9825bdac" sha1="6ddbba92cd301f755649bbe3321b2de52bb07069" offset="0" />
@@ -2661,7 +2661,7 @@ Compiled by K1W1
 		<description>Ham Text v1.1</description>
 		<year>198?</year>
 		<publisher>Kantronics</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="hamtext v1.1.rom" size="8192" crc="3601b0fa" sha1="18d47cf1bd986cdda2a003580bb9dd7fe42345cb" offset="0" />
@@ -2673,7 +2673,7 @@ Compiled by K1W1
 		<description>Homebase Electronic Banking</description>
 		<year>1982</year>
 		<publisher>Citibank</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="homebase electronic banking.rom" size="8192" crc="b792d41e" sha1="e0bb722b4f1f0b6be893a0e4c565b0233b49bc76" offset="0" />
@@ -2685,7 +2685,7 @@ Compiled by K1W1
 		<description>Hypnotic Land</description>
 		<year>1992</year>
 		<publisher>Lindasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="hypnotic land.rom" size="16384" crc="4fb75909" sha1="38f92ba44a205bf3ba758e7e7439c057e7682f1e" offset="0" /> <!-- Verified -->
@@ -2697,7 +2697,7 @@ Compiled by K1W1
 		<description>InstaDOS (Pirate)</description>
 		<year>2002</year>
 		<publisher>Sunmark</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="instados.rom" size="16384" crc="1003538a" sha1="01d322f67699f413f1163ce7c9960d9b97959534" offset="0" />
@@ -2709,7 +2709,7 @@ Compiled by K1W1
 		<description>INFO/soft 3000 Text Generator v3.3</description>
 		<year>1986</year>
 		<publisher>INFO/soft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="info-soft 3000.rom" size="16384" crc="6c104750" sha1="29d477e56910c79c06dde1718b0ff31bc7b8e5e2" offset="0" /> <!-- Verified -->
@@ -2721,7 +2721,7 @@ Compiled by K1W1
 		<description>INFO/soft 5000 Graphic Generator v5.3</description>
 		<year>1986</year>
 		<publisher>INFO/soft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="info-soft 5000.rom" size="16384" crc="66a53fa1" sha1="7be942cf2c66305bbf9575f57c7155953f50e8a8" offset="0" />
@@ -2734,7 +2734,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4019" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="in-store demonstration.rom" size="16384" crc="9bedcdf3" sha1="c20260e9150c4dc6489dc45af0df49bd56e20002" offset="0" /> <!-- Verified -->
@@ -2747,7 +2747,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1380" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="james bond 007.rom" size="16384" crc="19b4e3a1" sha1="00fc2ee7d1085a348a9260915d34a4130b22ad09" offset="0" /> <!-- Verified -->
@@ -2761,7 +2761,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="JBL-202" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="jawbreaker 2.rom" size="8192" crc="e2a63a2d" sha1="ef7b7693c313b4ca287e09bd7392c9d533179dd2" offset="0" /> <!-- Verified -->
@@ -2773,7 +2773,7 @@ Compiled by K1W1
 		<description>Jinks</description>
 		<year>20??</year>
 		<publisher>Video 61 / Williams</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="jinks.rom" size="65536" crc="39fe57ee" sha1="5b9be0502110e4fe493e9a767a0593db4fdd32bf" offset="0" />
@@ -2786,7 +2786,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01124" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="journey to the planets.rom" size="16384" crc="dce59b65" sha1="447144eee522fd1d9c05aabf99fe6b2cccc69815" offset="0" /> <!-- Verified -->
@@ -2800,7 +2800,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8044" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="joust.rom" size="16384" crc="f6ec618c" sha1="975c5b3f818d20c5feb868a25159a678f8c34e1b" offset="0" /> <!-- Verified -->
@@ -2812,7 +2812,7 @@ Compiled by K1W1
 		<description>Jr. Pac-Man (Reproduction)</description>
 		<year>1997</year>
 		<publisher>Video 61 / Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="jr pac-man (repro).rom" size="16384" crc="ebc1db55" sha1="39fe5fdcf7905af9d4cba4c06011f0e8a9364ff9" offset="0" />
@@ -2825,7 +2825,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THA12002" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="jumbo jet pilot.rom" size="16384" crc="f046332b" sha1="2f37f7e9f4ead4c425ab24c6dad342e723bd8973" offset="0" /> <!-- Verified -->
@@ -2838,7 +2838,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="594R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="jumpman junior.rom" size="16384" crc="6c79bbad" sha1="286cdc4434cd20e6e65e1a00bc88c0a17c0cfe12" offset="0" /> <!-- Verified -->
@@ -2851,7 +2851,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8049" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="jungle hunt.rom" size="16384" crc="1847a7d4" sha1="f35d0bb1a67d63d222403a77d1e6cd489eddbc84" offset="0" /> <!-- Verified -->
@@ -2864,7 +2864,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>CBS Software / K-Byte</publisher>
 		<info name="serial" value="M8786" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-razy antiks.rom" size="8192" crc="ab7bdb79" sha1="05c2e139053fc07571395a162b16a8c907036454" offset="0" /> <!-- Verified -->
@@ -2878,7 +2878,7 @@ Compiled by K1W1
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="M8788" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-razy kritters (cbs).rom" size="8192" crc="f854a3b4" sha1="b050ebad797f05fc94276f79cd7e4dcfa5f36f34" offset="0" /> <!-- Verified -->
@@ -2892,7 +2892,7 @@ Compiled by K1W1
 		<publisher>K-Byte</publisher>
 		<info name="serial" value="ATR1001" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-razy kritters (k-byte).rom" size="8192" crc="50354927" sha1="052c7ab5a083bd7266b8f86d7d4951c77bd005f3" offset="0" />
@@ -2905,7 +2905,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="M8784" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-razy shoot out (cbs).rom" size="8192" crc="636a01f5" sha1="a863ddeb8bdf8c39fc77e28d9aaa435c057928d4" offset="0" /> <!-- Verified -->
@@ -2918,7 +2918,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>K-Byte</publisher>
 		<info name="serial" value="ATR1000" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-razy shoot out (k-byte).rom" size="8192" crc="4300f6ff" sha1="4533c4c2847d9aab094337ec2b53148f289a0119" offset="0" /> <!-- Verified -->
@@ -2931,7 +2931,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>CBS Software / K-Byte</publisher>
 		<info name="serial" value="M8790" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="k-star patrol.rom" size="8192" crc="89c82cc2" sha1="87700f2c795922b7ceff6dae8261243eb20a9762" offset="0" /> <!-- Verified -->
@@ -2944,7 +2944,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-002-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="kaboom!.rom" size="8192" crc="c2e2e645" sha1="f9275d682581e6a07f2e23831bdf40ab3757ae12" offset="0" /> <!-- Verified -->
@@ -2957,7 +2957,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="kangaroo (proto).rom" size="16384" crc="1ef94906" sha1="3e9f61a5e7831d4570cf4b150415c054df419d4d" offset="0" />
@@ -2970,7 +2970,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-006-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="keystone kapers.rom" size="8192" crc="465e1763" sha1="1eb11b8d792960578958054fd3c5593910fa22ee" offset="0" /> <!-- Verified -->
@@ -2983,7 +2983,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12004" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="kickback.rom" size="8192" crc="2480ed0a" sha1="47f290c86d5456d1e0ac24085c2a64d7513a597c" offset="0" /> <!-- Verified -->
@@ -2996,7 +2996,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="KOK-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="kids on keys.rom" size="8192" crc="60615a91" sha1="363eb343215813c596a9a57a131542765283065d" offset="0" />
@@ -3009,7 +3009,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="KDC-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="kindercomp.rom" size="8192" crc="f1c45e24" sha1="c5a37311aba5c38121aea120b8a37ff4b26660d3" offset="0" /> <!-- Verified -->
@@ -3022,7 +3022,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Koala</publisher>
 		<info name="serial" value="AT00315-001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<feature name="peripheral" value="koala_pad,koala_pen" /> <!-- Works with Koala pad &amp; Koala light pen devices -->
 			<dataarea name="rom" size="16384">
@@ -3035,7 +3035,7 @@ Compiled by K1W1
 		<description>Laser Gates (Pirate)</description>
 		<year>1984</year>
 		<publisher>Imagic</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="laser gates.rom" size="16384" crc="ea2a103e" sha1="ba57e426cad7e636160177e4690c62a4e5d8c76d" offset="0" />
@@ -3048,7 +3048,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="LLL-201" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="learning with leeper.rom" size="16384" crc="5af1b0ec" sha1="eed7c2f10faeb9b8b8b15f322de08ec7bce9b741" offset="0" />
@@ -3063,7 +3063,7 @@ Compiled by K1W1
 		<info name="serial" value="10011A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="leo's 'lectric paintbrush.rom" size="8192" crc="da931cb5" sha1="88c9433d5964e701f232dcc83638d96a895252a9" offset="0" />
@@ -3079,7 +3079,7 @@ Compiled by K1W1
 		<info name="serial" value="10011A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="leo's 'lectric paintbrush (fixed).rom" size="8192" crc="3c66ea77" sha1="eca7d0c68c969ecce479258d05852ac3dba8ef0f" offset="0" />
@@ -3092,7 +3092,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>LJK</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="letter perfect (40 column).rom" size="8192" crc="34c1701a" sha1="325fad1512c8cff544f0e706eecd0c98ef2e0d1e" offset="0" />
@@ -3105,7 +3105,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>LJK</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="letter perfect (40 column)(alt).rom" size="8192" crc="88f5375f" sha1="a00370c48876b688d2b0cf6267510c18f88d89fd" offset="0" />
@@ -3119,7 +3119,7 @@ Compiled by K1W1
 		<publisher>LJK</publisher>
 		<info name="usage" value="Needs an Bit-3 80 Column Board or Austin-Franklin 80-Column Board to run." />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="letter perfect (80 column).rom" size="8192" crc="616e6cb0" sha1="c1e29309e28cfdefc3d1b32d08ca8ac84a479c84" offset="0" />
@@ -3131,7 +3131,7 @@ Compiled by K1W1
 		<description>Letter Tutor (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<feature name="peripheral" value="cx75_pen" /> <!-- Works with the Atari CX75 light pen device -->
 			<dataarea name="rom" size="8192">
@@ -3144,7 +3144,7 @@ Compiled by K1W1
 		<description>Lifespan (Prototype)</description>
 		<year>1983</year>
 		<publisher>Roklan</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="lifespan (proto).rom" size="16384" crc="e4d62c12" sha1="e65163a63515a2ab66ba0b8777980ee7f62bc001" offset="0" />
@@ -3157,7 +3157,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Fisher-Price</publisher>
 		<info name="serial" value="LNL-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="linking logic.rom" size="8192" crc="2484be4c" sha1="4620e341807cc061847dfdc954a537511762f81a" offset="0" /> <!-- Verified -->
@@ -3170,7 +3170,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Fisher-Price</publisher>
 		<info name="serial" value="LLV-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="logic levels.rom" size="8192" crc="c643f703" sha1="8aa85ccacd64a9b35193a7281ff729ea617f89b7" offset="0" /> <!-- Verified -->
@@ -3185,7 +3185,7 @@ Compiled by K1W1
 		<info name="serial" value="10042A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="logicmaster.rom" size="8192" crc="618bf3db" sha1="addaf5244108f9a7ae7fb40641cf152f149f27b6" offset="0" />
@@ -3201,7 +3201,7 @@ Compiled by K1W1
 		<info name="serial" value="10042A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="logicmaster (fixed).rom" size="8192" crc="552127ce" sha1="e52d91314c59087edb4eb279c5e7ab7c6892ef2a" offset="0" />
@@ -3214,7 +3214,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Romox / 20th Century Fox</publisher>
 		<info name="serial" value="ECPC-01033" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mash.rom" size="8192" crc="fa041093" sha1="4280c1fa77fc30b3b353100827e1374c117fd4c3" offset="0" />
@@ -3226,7 +3226,7 @@ Compiled by K1W1
 		<description>MAC-65 Macro Assembler v1.02</description>
 		<year>1984</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss034m" />
 			<dataarea name="rom" size="16384">
 				<rom name="mac-65 macro assembler v1.02.rom" size="16384" crc="51931a08" sha1="48e5d5e71d6c7b00f9429e90ef7514d3226a2bcf" offset="0" />
@@ -3238,7 +3238,7 @@ Compiled by K1W1
 		<description>MAC-65 Macro Assembler v1.01</description>
 		<year>1984</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_ossm091" />
 			<dataarea name="rom" size="16384">
 				<rom name="mac-65 macro assembler v1.01.rom" size="16384" crc="4102ca4f" sha1="2143a8317e85ec7eb27770a9f38e63867e41014b" offset="0" />
@@ -3250,7 +3250,7 @@ Compiled by K1W1
 		<description>MAC-65 Macro Assembler v1.00</description>
 		<year>1984</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss043m" />
 			<dataarea name="rom" size="16384">
 				<rom name="mac-65 macro assembler v1.0.rom" size="16384" crc="5e033719" sha1="13197d3c67efc7df429480bd0cd784bd62268b50" offset="0" />
@@ -3264,7 +3264,7 @@ Compiled by K1W1
 		<publisher>Gemini Software</publisher>
 		<info name="usage" value="BASIC must be enabled." />
 		<sharedfeat name="compatibility" value="Right Slot"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k_right" />
 			<dataarea name="rom" size="8192">
 				<rom name="magic dump 2.rom" size="8192" crc="8184c0d4" sha1="705c5f41c6ed6c638f424728dd6a9afd074665ae" offset="0" />
@@ -3276,7 +3276,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 01 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 1.rom" size="65536" crc="da0a5ae4" sha1="44951a131e906395e14727915e791f4a011a63a0" offset="0" />
@@ -3288,7 +3288,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 02 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 2.rom" size="65536" crc="2d200f74" sha1="da57c3c29b4139d7f8e84af2e0674db359b8d248" offset="0" />
@@ -3301,7 +3301,7 @@ Compiled by K1W1
 		<!-- The last game (Hot Lips) doesn't run. Possible Bad dump. -->
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 3 [b].rom" size="65536" crc="914372c0" sha1="220e769dd0a4b7237af27e6d73391e5016fbed63" offset="0" status="baddump" />
@@ -3313,7 +3313,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 04 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 4.rom" size="65536" crc="8e12b596" sha1="d444c50463ef208667997343663596b94f482c56" offset="0" />
@@ -3325,7 +3325,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 05 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 5.rom" size="65536" crc="e4ee1623" sha1="93722a32130b481f3f99d2b47c01db5461e1525b" offset="0" />
@@ -3337,7 +3337,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 06 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 6.rom" size="65536" crc="85ecbc95" sha1="02e6eef1ce699fe330b9bfa40660789dcec50cd9" offset="0" />
@@ -3349,7 +3349,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 07 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 7.rom" size="65536" crc="def97719" sha1="98eb12dc988ae08ca8112dcc189a188027ef520d" offset="0" />
@@ -3361,7 +3361,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 08 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 8.rom" size="65536" crc="a2b4ee4d" sha1="d1f3624f8513204c74726880a231b06dd9499cf4" offset="0" />
@@ -3373,7 +3373,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 09 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 9.rom" size="65536" crc="00241602" sha1="3e43e0783db4d0feb4229b5f91917c5778dd5ea7" offset="0" />
@@ -3385,7 +3385,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 10 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 10.rom" size="65536" crc="629bc83b" sha1="94d928c9deb9a51554b4f7805d480d19ba9ebc0f" offset="0" />
@@ -3397,7 +3397,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 11 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 11.rom" size="65536" crc="aafe6b95" sha1="da890904d96322c49992e1867a858bf4d9170d47" offset="0" />
@@ -3410,7 +3410,7 @@ Compiled by K1W1
 		<!-- The last game (Rescue on Fractalus) doesn't run. Possible Bad dump. -->
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 12.rom" size="65536" crc="1014548a" sha1="7bd519d68cee4ba74b3ec405561347ea09691fc1" offset="0" />
@@ -3422,7 +3422,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 13 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 13.rom" size="65536" crc="acbe80d9" sha1="001037c9f18d3e1433a5713bb30361b7f82f0811" offset="0" />
@@ -3434,7 +3434,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 14 (Spa, Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 14.rom" size="65536" crc="722e760e" sha1="5f3d45f8cfd765bebb2197e842dec8a3e5895193" offset="0" />
@@ -3446,7 +3446,7 @@ Compiled by K1W1
 		<description>Mega Cartridge 15 (Pirate)</description>
 		<year>2004</year>
 		<publisher>Willysoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="mega cartridge 15.rom" size="65536" crc="04d3a9fb" sha1="607b2706fb7d7b783900936329f0286e5e4767df" offset="0" />
@@ -3458,7 +3458,7 @@ Compiled by K1W1
 		<description>Meteor (Pirate)</description>
 		<year>198?</year>
 		<publisher>Germ-Soft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="meteor.rom" size="8192" crc="c27ff7df" sha1="9ec965060e7215b0a490fd50709838b51e462e67" offset="0" />
@@ -3471,7 +3471,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12009" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="major league hockey.rom" size="8192" crc="4ffbc999" sha1="82a1728e385d842a5a921c9cfd18661a186c914a" offset="0" /> <!-- Verified -->
@@ -3484,7 +3484,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Scarborough Systems</publisher>
 		<info name="serial" value="102" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="master type.rom" size="16384" crc="972ed894" sha1="edea6b93e57a5ca6e2c7962b774ea1c2b5fb6962" offset="0" /> <!-- Verified -->
@@ -3496,7 +3496,7 @@ Compiled by K1W1
 		<description>Math Encounter</description>
 		<year>1984</year>
 		<publisher>Hsu Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="math encounter.rom" size="8192" crc="9eaba275" sha1="a38a53102200b5f942dce204abfcd9dedca3c997" offset="0" /> <!-- Verified -->
@@ -3509,7 +3509,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="75010" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="math mileage.rom" size="8192" crc="c8b311bf" sha1="864834bac2a5a005151fbe7579b6881cae3a9de6" offset="0" /> <!-- Verified -->
@@ -3521,7 +3521,7 @@ Compiled by K1W1
 		<description>Math Works - Addition</description>
 		<year>1985</year>
 		<publisher>Concepts for Darren</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="math works - addition.rom" size="8192" crc="fb350372" sha1="66368894bcb81bd49d19beb2c7af68de5f1395fe" offset="0" />
@@ -3533,7 +3533,7 @@ Compiled by K1W1
 		<description>Math Works - Subtraction</description>
 		<year>1985</year>
 		<publisher>Concepts for Darren</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="math works - subtraction.rom" size="8192" crc="4bb5541a" sha1="da8d38c72112cf1f55f53de61e9587ba221d2dfa" offset="0" />
@@ -3545,7 +3545,7 @@ Compiled by K1W1
 		<description>Matterhorn</description>
 		<year>1984</year>
 		<publisher>Tigervision</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="matterhorn.rom" size="16384" crc="dcc308cf" sha1="c03815e4038bf94134b76a255378250ef12c1d50" offset="0" /> <!-- Verified -->
@@ -3558,7 +3558,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mcdonald's pac-mac (beta 2).rom" size="8192" crc="ca961d16" sha1="00078ebe4a1c3159cfa7740472daa7dda4b6b8bb" offset="0" />
@@ -3571,7 +3571,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mcdonald's pac-mac (beta 1).rom" size="8192" crc="209d2e17" sha1="eaa5ede5af74fc5c67a0934f32412832e9787eba" offset="0" />
@@ -3584,7 +3584,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>BOT Engineering</publisher>
 		<info name="usage" value="Pocket Modem required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="pocket modem v2.08.rom" size="8192" crc="710aea7a" sha1="ad8ddac51acb13518067d1b54228265b4aec4928" offset="0" />
@@ -3597,7 +3597,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-003-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="megamania.rom" size="8192" crc="b3c5130c" sha1="ff4a574183168c3e98b2530d69734251a4b12508" offset="0" /> <!-- Verified -->
@@ -3610,7 +3610,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Fisher-Price</publisher>
 		<info name="serial" value="MEM-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="memory manor.rom" size="8192" crc="aedcbd0b" sha1="e67e5c494a71727a526b9af6af8746401531af8c" offset="0" /> <!-- Verified -->
@@ -3622,7 +3622,7 @@ Compiled by K1W1
 		<description>Microfiler</description>
 		<year>1983</year>
 		<publisher>MPP</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="microfiler.rom" size="8192" crc="c3b283e6" sha1="6017ce3f3f836ab0ee143e72401af1daa44b3a09" offset="0" /> <!-- Verified -->
@@ -3634,7 +3634,7 @@ Compiled by K1W1
 		<description>Microcalc XE v2.2 (Mex)</description>
 		<year>19??</year>
 		<publisher>Grupo SITSA</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sitsa" />
 			<dataarea name="rom" size="32768">
 				<rom name="microcalc v2.2.rom" size="32768" crc="44507065" sha1="ac2e0ddac58fba9d0f8a01c26ee857b769c62a98" offset="0" />
@@ -3646,7 +3646,7 @@ Compiled by K1W1
 		<description>Microprinter System 800</description>
 		<year>1983</year>
 		<publisher>MSI</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="microprinter system 800.rom" size="8192" crc="7b222136" sha1="d34b8e7ba4624fe83606d9a7ee9ccb25fa249222" offset="0" /> <!-- Verified -->
@@ -3658,7 +3658,7 @@ Compiled by K1W1
 		<description>Microprinter System 400</description>
 		<year>1983</year>
 		<publisher>MSI</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="microprinter system 400.rom" size="8192" crc="89c66405" sha1="594c475811441807944ac262d40d08d8cd714f19" offset="0" />
@@ -3673,7 +3673,7 @@ Compiled by K1W1
 		<info name="serial" value="10016A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="micro illustrator.rom" size="16384" crc="5d5f76f6" sha1="72a3d1efb6d8582680fa61067139d4eb27128906" offset="0" /> <!-- Verified -->
@@ -3688,7 +3688,7 @@ Compiled by K1W1
 		<info name="serial" value="10021A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="micromaestro.rom" size="8192" crc="98915118" sha1="179106c5653023271974379d58496194f9ab20cf" offset="0" />
@@ -3704,7 +3704,7 @@ Compiled by K1W1
 		<info name="serial" value="10021A-3" />
 		<info name="usage" value="Chalkboard Inc.'s Powerpad Tablet required" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="micromaestro (fixed).rom" size="8192" crc="1d45435f" sha1="19da5dbb8606f2e42a3d034ba0c92b49435e7da8" offset="0" />
@@ -3718,7 +3718,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8048" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="millipede.rom" size="16384" crc="fb7e45da" sha1="957ae30c14efaa8c05d270fd232676b0d03a1b41" offset="0" /> <!-- Verified -->
@@ -3730,7 +3730,7 @@ Compiled by K1W1
 		<description>Millipede (Prototype)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="millipede (prototype).rom" size="16384" crc="82457872" sha1="366ac736b9f56cf723302fb36778f76da779e459" offset="0" />
@@ -3742,7 +3742,7 @@ Compiled by K1W1
 		<description>Miner 2049er</description>
 		<year>1982</year>
 		<publisher>Big Five Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="miner 2049er.rom" size="16384" crc="7df1adfb" sha1="0564b1867a0b570d66dfcbc11adc3e51a2c6f28c" offset="0" /> <!-- Verified -->
@@ -3755,7 +3755,7 @@ Compiled by K1W1
 		<!-- This earlier version had a game play bug on level 6. -->
 		<year>1982</year>
 		<publisher>Big Five Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="miner 2049 (earlier release).rom" size="16384" crc="eb770df4" sha1="a1cd696699bebe26fd61514f63e8ac1758f0007a" offset="0" />
@@ -3768,7 +3768,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4012" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<feature name="peripheral" value="trackball" /> <!-- Works with Trackball controller -->
 			<dataarea name="rom" size="8192">
@@ -3781,7 +3781,7 @@ Compiled by K1W1
 		<description>Missile Command+ (Hack)</description>
 		<year>2006</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<feature name="peripheral" value="trackball" /> <!-- Works with Trackball controller -->
 			<dataarea name="rom" size="16384">
@@ -3795,7 +3795,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Romox / Amiga</publisher>
 		<info name="serial" value="ECPC-03220" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="mogul maniac.rom" size="16384" crc="0c391600" sha1="20a17978d2b30aaa98db66cac4cc4e1432141ce1" offset="0" />
@@ -3809,7 +3809,7 @@ Compiled by K1W1
 		<publisher>Epyx</publisher>
 		<info name="serial" value="564R" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="monster maze.rom" size="8192" crc="37049e57" sha1="4f5d333118e2bc69a4c6e18c36c9364f53470baf" offset="0" /> <!-- Verified -->
@@ -3821,7 +3821,7 @@ Compiled by K1W1
 		<description>Montezuma's Revenge (Prototype)</description>
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="montezuma's revenge (proto).rom" size="16384" crc="bd4404d9" sha1="3f79100c2e981fa16fbc7ff263584bf1a4a63e2e" offset="0" />
@@ -3833,7 +3833,7 @@ Compiled by K1W1
 		<description>Moogles (Pirate)</description>
 		<year>1983</year>
 		<publisher>Sirius</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="moogles.rom" size="16384" crc="0585fb5a" sha1="87c5aaa98a680ab5fc00f18357d3dbf45d457882" offset="0" />
@@ -3847,7 +3847,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8052" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="moon patrol.rom" size="16384" crc="b845edb8" sha1="55b66f8e5dda90035f8c53f5317e95d3b55d57c8" offset="0" /> <!-- Verified -->
@@ -3860,7 +3860,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-2541" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mountain king.rom" size="8192" crc="79748c93" sha1="5e8efb41e2051627a9f0397d405f5f852e522490" offset="0" /> <!-- Verified -->
@@ -3873,7 +3873,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9849" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="movie musical madness.rom" size="16384" crc="0d8f719b" sha1="1e5bf12d472e795a8cb1f8abf9c7456211416d1c" offset="0" /> <!-- Verified -->
@@ -3885,7 +3885,7 @@ Compiled by K1W1
 		<description>Mr. Do!'s Castle (Prototype)</description>
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mr do!'s castle (proto).rom" size="8192" crc="abed3b88" sha1="c44711b34d3a2372d39a34b9cab25ba96bc6d504" offset="0" />
@@ -3898,7 +3898,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="MCL-201" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mr cool.rom" size="8192" crc="1345d10c" sha1="e3073791797c18dfd7ca8e73e0bfb5637ddb48e0" offset="0" /> <!-- Verified -->
@@ -3911,7 +3911,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>HES</publisher>
 		<info name="serial" value="C730" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="mr tnt.rom" size="8192" crc="701dbdea" sha1="e3129963ab78c64511dcad6539367d3e9dc7ad32" offset="0" /> <!-- Verified -->
@@ -3925,7 +3925,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8043" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ms pac-man (red cherry).rom" size="16384" crc="4ad748b2" sha1="7c0ff13751169854fc5a80b1375ea4ee1d7ff0c1" offset="0" /> <!-- Verified -->
@@ -3940,7 +3940,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8043" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ms pac-man (green cherry).rom" size="16384" crc="f91d18cf" sha1="c8620e435ca7a49252dad309a4cba600c59d95ea" offset="0" /> <!-- Verified -->
@@ -3952,7 +3952,7 @@ Compiled by K1W1
 		<description>Multi Fischa (Mex)</description>
 		<year>1985</year>
 		<publisher>Grupo SITSA</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="multificha.rom" size="8192" crc="78e680da" sha1="c477b08c709d662b4e769b83be239776ae66a25d" offset="0" />
@@ -3965,7 +3965,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4007" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="music composer.rom" size="8192" crc="2aca9cee" sha1="20b3e86cdffba4dbf256c372bcc3d00a41a95359" offset="0" /> <!-- Verified -->
@@ -3977,7 +3977,7 @@ Compiled by K1W1
 		<description>MyDOS v3.116 (Pirate)</description>
 		<year>1985</year>
 		<publisher>Wordmark</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="mydos v3.116.rom" size="16384" crc="462a3d98" sha1="8c529acb5a9ba2882196b22c2f553979452dcddd" offset="0" />
@@ -3989,7 +3989,7 @@ Compiled by K1W1
 		<description>Night Strike!</description>
 		<year>1983</year>
 		<publisher>TG Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="night strike!.rom" size="8192" crc="61245a75" sha1="b307df40cc03d7f990aebf5e3ec7c9087087e343" offset="0" /> <!-- Verified -->
@@ -4002,7 +4002,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sierra On-Line</publisher>
 		<info name="serial" value="OWL-801" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="oil's well.rom" size="16384" crc="030ecad6" sha1="f982c17a8daef1874456baae72f77dca86cb48a8" offset="0" /> <!-- Verified -->
@@ -4015,7 +4015,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THA12008" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="orc attack.rom" size="16384" crc="5e9849b1" sha1="bad95db8dd81824d19484c3543b617e30fccb735" offset="0" />
@@ -4028,7 +4028,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THA12008" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="orc attack (a).rom" size="16384" crc="fbfaefcd" sha1="4e42caa95764f33f988bd7bab75268d66d203530" offset="0" />
@@ -4040,7 +4040,7 @@ Compiled by K1W1
 		<description>Ozzy's Orchard</description>
 		<year>1983</year>
 		<publisher>TG Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="ozzy's orchard.rom" size="16384" crc="1554b983" sha1="334254c392cc14d0f64f71954292322772ab514c" offset="0" /> <!-- Verified -->
@@ -4054,7 +4054,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4022" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="pac-man.rom" size="8192" crc="61cf6167" sha1="bc600ef63f8d1bdd3911981c2752ea23db959960" offset="0" /> <!-- Verified -->
@@ -4066,7 +4066,7 @@ Compiled by K1W1
 		<description>Paddle Jitter Test (Rev. C)</description>
 		<year>1982</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="paddle jitter test (rev c).rom" size="16384" crc="0366db59" sha1="7424663cdf6087a0fbce51bb9ba7cc8be135997d" offset="0" />
@@ -4079,7 +4079,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CC-104-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 					<rom name="pastfinder.rom" size="16384" crc="14fddfb8" sha1="5fa7c9c35ee8b1a844222f035ab4e99a0eb7f9fd" offset="0" /> <!-- Verified -->
@@ -4091,7 +4091,7 @@ Compiled by K1W1
 		<description>Explorer (Prototype)</description>
 		<year>1984</year>
 		<publisher>Activision</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 					<rom name="explorer (proto).rom" size="16384" crc="98a4e5b7" sha1="c00061d53278403e846cf3d008cbc2e2b862081e" offset="0" />
@@ -4104,7 +4104,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0110" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="peanut butter panic.rom" size="8192" crc="cdeb7759" sha1="ed857bebe7502f97322fe108952591dbd001f61c" offset="0" /> <!-- Verified -->
@@ -4117,7 +4117,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8045" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pengo.rom" size="16384" crc="d8a9fe0a" sha1="2c0cb48caeb77b25551d27fade419454fa2fd114" offset="0" /> <!-- Verified -->
@@ -4130,7 +4130,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="picnic paranoia.rom" size="16384" crc="e386a621" sha1="b63514aa944b8771a4a12d5f8c661cac8e04dd06" offset="0" /> <!-- Verified -->
@@ -4143,7 +4143,7 @@ Compiled by K1W1
 		<year>1980</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4018" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="pilot computing language.rom" size="8192" crc="3a695b4c" sha1="8a11ed7befcd5919440db16734d41c5c4e5c1776" offset="0" /> <!-- Verified -->
@@ -4156,7 +4156,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-004-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="pitfall!.rom" size="8192" crc="b58bdf1c" sha1="9487baa01e3ba56d082fadec56e8ddee1cde3486" offset="0" /> <!-- Verified -->
@@ -4169,7 +4169,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CA-011-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pitfall! 2 - lost caverns.rom" size="16384" crc="1668cf3b" sha1="74483a0bf38c61b495268591396d65e1a9518101" offset="0" /> <!-- Verified -->
@@ -4182,7 +4182,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="604R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pitstop.rom" size="16384" crc="d49ebf91" sha1="a3b7541c57a51ced98084027e0b9b15637359c54" offset="0" /> <!-- Verified -->
@@ -4195,7 +4195,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="usage" value="Requires Atari 850 interface and 1200 baud modem to run." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="plato.rom" size="8192" crc="47b49425" sha1="7b54326d07b93c1969f6321679c1199a47216f27" offset="0" />
@@ -4208,7 +4208,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="554R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="plattermania.rom" size="8192" crc="6cef6f94" sha1="a09bfd7864220582ec8317ea914d0b25247146b7" offset="0" /> <!-- Verified -->
@@ -4222,7 +4222,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8034" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pole position.rom" size="16384" crc="581570c4" sha1="57bbb668072241925cc8d19561cc0d47b3d6a570" offset="0" /> <!-- Verified -->
@@ -4235,7 +4235,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>IDSI</publisher>
 		<info name="serial" value="AC1001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="pool 400.rom" size="8192" crc="a6c2130f" sha1="55d2118259e58d33f99dbebdaff43df531ce6585" offset="0" /> <!-- Verified -->
@@ -4247,7 +4247,7 @@ Compiled by K1W1
 		<description>Rack 'em Up! (Re-Badged)</description>
 		<year>1983</year>
 		<publisher>Roklan</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="rack 'em up!.rom" size="16384" crc="5335d935" sha1="e5d2a855b46883d6247c591a7ecd30bd240c6aad" offset="0" />
@@ -4260,7 +4260,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1150" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="popeye (us).rom" size="16384" crc="00fce79a" sha1="c1c4499bf7cbb3ebeb1f10eed2fe8962df6a8ad3" offset="0" /> <!-- Verified -->
@@ -4273,7 +4273,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1150" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="popeye (eu).rom" size="16384" crc="a35d5e6a" sha1="5dcef8b50bc32b305846867ff9039b65841490c0" offset="0" /> <!-- Verified -->
@@ -4286,7 +4286,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Romox / 20th Century Fox</publisher>
 		<info name="serial" value="ECPC-02033" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="porky's.rom" size="16384" crc="1733d3fc" sha1="139f9075247ca1526ae5a7ac68927b496a940226" offset="0" />
@@ -4298,7 +4298,7 @@ Compiled by K1W1
 		<description>Powerstar</description>
 		<year>1985</year>
 		<publisher>Pandora Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="powerstar.rom" size="16384" crc="dc0dca6e" sha1="7e636709a2612018f409561680b26bb92fab2e56" offset="0" /> <!-- Verified -->
@@ -4311,7 +4311,7 @@ Compiled by K1W1
 		<!-- Re-package & Re-release of Adventure International 1982 release. -->
 		<year>2001</year>
 		<publisher>Video 61 / Adventure International</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="preppie.rom" size="16384" crc="52ae50e3" sha1="65b801796ba970b391d983a488c11a23c3f76d6b" offset="0" />
@@ -4324,7 +4324,7 @@ Compiled by K1W1
 		<!-- Part of the EPG Jr. on-line cable TV guide system -->
 		<year>1991</year>
 		<publisher>Prevue Networks</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="prevue rev.06.rom" size="16384" crc="e09633a6" sha1="bdbf8995d0eff72540a12cf811c7528d6d5e6a60" offset="0" />
@@ -4336,7 +4336,7 @@ Compiled by K1W1
 		<description>Princess and the Frog</description>
 		<year>1982</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="princess and the frog.rom" size="8192" crc="7ce79281" sha1="eaa63bb404248aae516872b069e78840932d18c5" offset="0" /> <!-- Verified -->
@@ -4348,7 +4348,7 @@ Compiled by K1W1
 		<description>Prisma 1 (Spa, Pirate)</description>
 		<year>199?</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 1.rom" size="65536" crc="fc2f3210" sha1="89b25b330b1d9789a70f2680926d283cbdb90ce5" offset="0" />
@@ -4360,7 +4360,7 @@ Compiled by K1W1
 		<description>Prisma 2 (Spa, Pirate)</description>
 		<year>199?</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 2.rom" size="65536" crc="6c79351e" sha1="09f1eba81aced69cf55536deda5fcfd33b6a1cfa" offset="0" />
@@ -4373,7 +4373,7 @@ Compiled by K1W1
 		<!-- The last game (Crystal Raider) doesn't run. Possible Bad dump. -->
 		<year>1992</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 3 [b].rom" size="65536" crc="a136fef3" sha1="9c621da086eaf221be4d9149ee49f67c342349cc" offset="0" status="baddump" />
@@ -4385,7 +4385,7 @@ Compiled by K1W1
 		<description>Prisma 4 (Spa, Pirate)</description>
 		<year>1992</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 4.rom" size="65536" crc="670c49c6" sha1="b0dfe38188b2917b244a845aad85533f2987da1a" offset="0" />
@@ -4397,7 +4397,7 @@ Compiled by K1W1
 		<description>Prisma 5 (Spa, Pirate)</description>
 		<year>1992</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 5.rom" size="65536" crc="ab71896a" sha1="66339b44c0e2775aa20a6ecad8e6281af2f8ea77" offset="0" />
@@ -4409,7 +4409,7 @@ Compiled by K1W1
 		<description>Prisma 6 (Spa, Pirate)</description>
 		<year>1992</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma 6.rom" size="65536" crc="8f7e24df" sha1="80c12cf4095afc1d42f76be407a5af7f9eeb34d0" offset="0" />
@@ -4421,7 +4421,7 @@ Compiled by K1W1
 		<description>Prisma Super 15-2 (Spa, Pirate)</description>
 		<year>1992</year>
 		<publisher>Prismasoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="prisma super 15-2.rom" size="65536" crc="62a7b77e" sha1="4962cf4ecf14a837210a588058d8f65708f7a353" offset="0" />
@@ -4434,7 +4434,7 @@ Compiled by K1W1
 		<year>1985</year>
 		<publisher>Pronto</publisher>
 		<info name="serial" value="22680" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pronto electronic banking.rom" size="16384" crc="f87e5a14" sha1="dbea9539300f676e659f71c2ff9b808d77fc7bc4" offset="0" />
@@ -4447,7 +4447,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Pronto</publisher>
 		<info name="serial" value="22680" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="pronto home information.rom" size="16384" crc="60094848" sha1="2791784a9d139c3f83ce2556a80fa27f27bcacae" offset="0" />
@@ -4460,7 +4460,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="protector 2.rom" size="16384" crc="374f311f" sha1="f31ae258139acf1bdf7fcfa26784b17fe42874ed" offset="0" /> <!-- Verified -->
@@ -4473,7 +4473,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1120" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="qbert.rom" size="8192" crc="ff3f0472" sha1="03fda6774715cc1005f46b18b995dd4a92ce903c" offset="0" /> <!-- Verified -->
@@ -4486,7 +4486,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4027" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="qix.rom" size="8192" crc="967b8051" sha1="0454ced8bdf47402dcda261ad12f6b805645bdbc" offset="0" /> <!-- Verified -->
@@ -4499,7 +4499,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Adventure International</publisher>
 		<info name="serial" value="053-0171" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="rally speedway.rom" size="16384" crc="0a0f6ea2" sha1="30b418c246ea43b16b9f70fdd875c6acbd9395ea" offset="0" /> <!-- Verified -->
@@ -4513,7 +4513,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8029" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="realsports football.rom" size="16384" crc="5e8951f4" sha1="2f615847f073d68b7f4718ed06e7054bab6888e9" offset="0" /> <!-- Verified -->
@@ -4527,7 +4527,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8042" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="tennis.rom" size="16384" crc="9a34cbdc" sha1="c9ec768a4a3de523d66b2d331e48bcc18d2f1a30" offset="0" /> <!-- Verified -->
@@ -4539,7 +4539,7 @@ Compiled by K1W1
 		<description>Risk (Prototype)</description>
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="risk (proto).rom" size="8192" crc="688b0a0c" sha1="a69ea43c39f8db965fe2b421f4ae3a817bad30d4" offset="0" />
@@ -4552,7 +4552,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-001-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="river raid.rom" size="8192" crc="6e601d81" sha1="107cb8847329f7d68282f54c95ae5533452b87fd" offset="0" /> <!-- Verified -->
@@ -4565,7 +4565,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12005" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="river rescue.rom" size="16384" crc="a7d2e0e8" sha1="6ed64649f000ddd44eaf46c0334301c7e9d75aac" offset="0" /> <!-- Verified -->
@@ -4578,7 +4578,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8033" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="robotron 2084.rom" size="16384" crc="528fc44a" sha1="604486feacd59499426e2f2d5cc66eabe25bfc68" offset="0" /> <!-- Verified -->
@@ -4590,7 +4590,7 @@ Compiled by K1W1
 		<description>Satan's Hollow (Unreleased)</description>
 		<year>1982</year>
 		<publisher>CBS Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="satan's hollow.rom" size="16384" crc="0f7c7934" sha1="654b64d0bad44d9cdb3a3211470ba4cf1c8876b0" offset="0" />
@@ -4602,7 +4602,7 @@ Compiled by K1W1
 		<description>Sea Chase</description>
 		<year>1983</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="sea chase.rom" size="8192" crc="99b5a1dd" sha1="4e511d2d935039d514889583a7584f718e02f09c" offset="0" /> <!-- Verified -->
@@ -4615,7 +4615,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Brøderbund</publisher>
 		<info name="serial" value="ATCART193" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="sea fox.rom" size="16384" crc="932cc9a8" sha1="7eeb3208453f22bcc8d8c7a06b54075c7ff8c9dd" offset="0" /> <!-- Verified -->
@@ -4628,7 +4628,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9890" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="sea horse hide 'n seek.rom" size="16384" crc="52964146" sha1="3ea5a49e59a13624b69b9450a7264d7051f81f0e" offset="0" /> <!-- Verified -->
@@ -4641,7 +4641,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Brøderbund</publisher>
 		<info name="serial" value="ATCART190" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="serpentine.rom" size="8192" crc="1b555b41" sha1="4f1dfee65bedb0626d4964ab0a5393416376c920" offset="0" /> <!-- Verified -->
@@ -4655,7 +4655,7 @@ Compiled by K1W1
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0365" />
 		<info name="usage" value="Keyboard overlay was supplied with cartridge" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="sesame street letter-go-round.rom" size="16384" crc="f525b904" sha1="14851876e2bb843559dc9d13a8afc5595bf1646b" offset="0" /> <!-- Verified -->
@@ -4668,7 +4668,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="shamus.rom" size="16384" crc="bd3f06ee" sha1="175d5dc0142ee092bcd263bd029e77f191322121" offset="0" /> <!-- Verified -->
@@ -4681,7 +4681,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Epyx</publisher>
 		<info name="serial" value="664R" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="silicon warrior.rom" size="16384" crc="a7ecc8f7" sha1="e8d3fd99c5aba88688f2e9023ff06e62fd5267db" offset="0" /> <!-- Verified -->
@@ -4693,7 +4693,7 @@ Compiled by K1W1
 		<description>Sistema Controlado por Computadora</description>
 		<year>1992</year>
 		<publisher>ZZ Top Soft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="sistema controlado por computadora.rom" size="65536" crc="d2159969" sha1="241f29de2497adfdc6474f387d59b9a1e7d46165" offset="0" />
@@ -4706,7 +4706,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8059" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="sky writer.rom" size="16384" crc="0a73a8f5" sha1="2c13733c770b2bd02bb7572b2831b86dfa9205f3" offset="0" /> <!-- Verified -->
@@ -4719,7 +4719,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="slime.rom" size="16384" crc="1babcad6" sha1="d2705b7990029dbfbd0282239aec80606753c760" offset="0" /> <!-- Verified -->
@@ -4731,7 +4731,7 @@ Compiled by K1W1
 		<description>SmartDOS v6.1D (Pirate)</description>
 		<year>1984</year>
 		<publisher>Rana Systems</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="smartdos v6.1d.rom" size="16384" crc="d68915fa" sha1="f87818a07f1190629c1772b366fa655d26ec2987" offset="0" />
@@ -4743,7 +4743,7 @@ Compiled by K1W1
 		<description>Smart Terminal v5.0</description>
 		<year>1983</year>
 		<publisher>MPP</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="smart terminal v5.0.rom" size="8192" crc="9b2d017b" sha1="9ed4179ea066ddb9751222fbffd1c3fea12c5346" offset="0" />
@@ -4755,7 +4755,7 @@ Compiled by K1W1
 		<description>Smart Terminal v4.1</description>
 		<year>1983</year>
 		<publisher>MPP</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="smart terminal v4.1.rom" size="8192" crc="f5c34344" sha1="73917bed05776d6f3cdd2590479bf2e86f14c2d4" offset="0" /> <!-- Verified -->
@@ -4768,7 +4768,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THB12003" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="soccer.rom" size="8192" crc="784c7060" sha1="efa59cd8919287e2cd1bc8149dc9867ec7d5e171" offset="0" /> <!-- Verified -->
@@ -4782,7 +4782,7 @@ Compiled by K1W1
 		<year>1980</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4008" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="space invaders.rom" size="8192" crc="3614d0aa" sha1="963fc3625a38fd5042a0efef4465274aa849dadc" offset="0" /> <!-- Verified -->
@@ -4795,7 +4795,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="09-01116" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="space journey.rom" size="16384" crc="161657f0" sha1="857439afc9d9f834175601ea8cede17ab1301dcf" offset="0" />
@@ -4808,7 +4808,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CA-012-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="space shuttle - a journey into space.rom" size="16384" crc="66832f68" sha1="d4b96474939ef906fa5980f298cc7226d5778b6e" offset="0" /> <!-- Verified -->
@@ -4820,7 +4820,7 @@ Compiled by K1W1
 		<description>Spark Bugs</description>
 		<year>1983</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="spark bugs.rom" size="8192" crc="f56eced2" sha1="70af5a7a19a7a03650c2e91b1e825c4b3e310432" offset="0" />
@@ -4832,7 +4832,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.18</description>
 		<year>1988</year>
 		<publisher>ICD</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.18.rom" size="65536" crc="e825e9ab" sha1="ffdaff6873ccd7641afc46546a5fdc8acb7d5d32" offset="0" />
@@ -4844,7 +4844,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.19</description>
 		<year>1989</year>
 		<publisher>ICD</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.19.rom" size="65536" crc="6bb5733c" sha1="57bcad630e7be290aa5d5436e886bb8fd2cec97a" offset="0" />
@@ -4856,7 +4856,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.2a</description>
 		<year>1989</year>
 		<publisher>ICD</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.2a.rom" size="65536" crc="e9f82c76" sha1="3ce5bb28e583748b66e2dbcc38ecd30bca6f2aae" offset="0" />
@@ -4868,7 +4868,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.20</description>
 		<year>1989</year>
 		<publisher>ICD</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.20.rom" size="65536" crc="781e045c" sha1="9c4296cd8b520e75cbe6fa7dfc06b12ef7ca5ce1" offset="0" />
@@ -4880,7 +4880,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.21</description>
 		<year>1989</year>
 		<publisher>ICD</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.21.rom" size="65536" crc="db0ca1eb" sha1="8b190e7fa5f77a7ccf609af3cbab09b64da7c923" offset="0" />
@@ -4892,7 +4892,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.22</description>
 		<year>1995</year>
 		<publisher>FTe</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="65536">
 				<rom name="spartados x v4.22.rom" size="65536" crc="de1ebece" sha1="b8170d8d3fda45ba09a3b0f67decd56cf3f9bd76" offset="0" />
@@ -4904,7 +4904,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.39rc</description>
 		<year>2006</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.39rc.rom" size="131072" crc="a3ec2e58" sha1="79ad6acd8a61fdcbf427d098c77d84282110a6ef" offset="0" />
@@ -4916,7 +4916,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.41</description>
 		<year>2008</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.41.rom" size="131072" crc="687c7a15" sha1="12fc71f8437528117079fff777838b7193d38fcc" offset="0" />
@@ -4928,7 +4928,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.42</description>
 		<year>2008</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.42.rom" size="131072" crc="0b4bcfc5" sha1="663fef048ddd76316dd193023c560631b161257b" offset="0" />
@@ -4940,7 +4940,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.43</description>
 		<year>2011</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.43.rom" size="131072" crc="48be5d1e" sha1="d0579bc19d0fa8938d1557924c2e1c3b968e02e7" offset="0" />
@@ -4952,7 +4952,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.44</description>
 		<year>2011</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.44.rom" size="131072" crc="337516b0" sha1="99518cab315b564b2f7621d6969709bf7ee7c5af" offset="0" />
@@ -4964,7 +4964,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.45</description>
 		<year>2011</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.45.rom" size="131072" crc="df4520c1" sha1="d7ae9dc6c7a5dbf3890be0a6a66c5cc0501a6ca9" offset="0" />
@@ -4976,7 +4976,7 @@ Compiled by K1W1
 		<description>Sparta DOS X v4.46</description>
 		<year>2013</year>
 		<publisher>DLT</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_sparta" />
 			<dataarea name="rom" size="131072">
 				<rom name="spartados x v4.46.rom" size="131072" crc="3254ee87" sha1="0123f640f56ef4be1bdabe3643770b72d4b0f396" offset="0" />
@@ -4990,7 +4990,7 @@ Compiled by K1W1
 		<publisher>IDSI</publisher>
 		<info name="serial" value="AC1021" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="speedway blast.rom" size="8192" crc="8e67192b" sha1="d819708553249cd63462a7001fb28702f4f165b8" offset="0" /> <!-- Verified -->
@@ -5003,7 +5003,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33015" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="spider city.rom" size="8192" crc="d519f2fb" sha1="41132f0aad74ac73e4c15bd6a7d4ea7e650ef417" offset="0" /> <!-- Verified -->
@@ -5016,7 +5016,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Tigervision</publisher>
 		<info name="serial" value="7-006-400" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="springer.rom" size="16384" crc="81466b55" sha1="7272ee5135be828c60af0565ac6c21f5d210388d" offset="0" /> <!-- Verified -->
@@ -5030,7 +5030,7 @@ Compiled by K1W1
 		<publisher>Sega</publisher>
 		<info name="serial" value="011-03" />
 		<info name="usage" value="2 joysticks required to play." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="spy hunter.rom" size="16384" crc="34df8ffc" sha1="999969fc114e5ba8ccaa1079ae0c613f07a898d2" offset="0" /> <!-- Verified -->
@@ -5042,7 +5042,7 @@ Compiled by K1W1
 		<description>Squish 'Em!</description>
 		<year>1983</year>
 		<publisher>Sirius</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="squish 'em!.rom" size="8192" crc="f0553d6c" sha1="e2f2ac31793bc587fc977137c08f83aa162198a4" offset="0" /> <!-- Verified -->
@@ -5055,7 +5055,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Roklan</publisher>
 		<info name="serial" value="11-01222" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="star maze.rom" size="16384" crc="6fd9daff" sha1="76c9b4dacaafdbf594727842413b2c680e60daad" offset="0" /> <!-- Verified -->
@@ -5068,7 +5068,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4011" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="star raiders.rom" size="8192" crc="5ec023ba" sha1="32b8ed4fcb95ba013a6b5b9c0676cb16f7672e43" offset="0" /> <!-- Verified -->
@@ -5081,7 +5081,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="004-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="star trek - strategic operations simulator.rom" size="16384" crc="9df169d9" sha1="d91f27803065f6b88f2f595c4b6503b76d16a4e4" offset="0" /> <!-- Verified -->
@@ -5095,7 +5095,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Atari</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="star trux (proto).rom" size="8192" crc="8212c4b7" sha1="0ad167b5fa57ef8e4e8ea82e0f22fe874aece8e8" offset="0" />
@@ -5108,7 +5108,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1260" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="star wars - return of the jedi - death star battle.rom" size="8192" crc="a40e15e5" sha1="2612a52591bb678d86af240ddc5619513941e6a6" offset="0" /> <!-- Verified -->
@@ -5121,7 +5121,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1340" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="star wars - the arcade game.rom" size="16384" crc="aea795f7" sha1="42c4e1685bad6847c5b6ee58d172a9bf9148bffa" offset="0" /> <!-- Verified -->
@@ -5133,7 +5133,7 @@ Compiled by K1W1
 		<description>Stargate (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="stargate (proto).rom" size="16384" crc="f527b721" sha1="ae833c0cfbb985193e53fbca84ca2893ce01c601" offset="0" />
@@ -5145,7 +5145,7 @@ Compiled by K1W1
 		<description>Starion</description>
 		<year>1983</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="starion.rom" size="16384" crc="23faf9b3" sha1="835d389dba0a61efe854346d22d78333ef5f88d8" offset="0" /> <!-- Verified -->
@@ -5158,7 +5158,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="SMC-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="story machine.rom" size="16384" crc="b3e7fe47" sha1="30012766920a7191c56ed9eddfd7c7307b99debc" offset="0" /> <!-- Verified -->
@@ -5171,7 +5171,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Thorn EMI</publisher>
 		<info name="serial" value="THA12001" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="submarine commander.rom" size="16384" crc="ce9562eb" sha1="54dd71f5b65ce7f6ac467e67c392d54c4b34efd8" offset="0" /> <!-- Verified -->
@@ -5185,7 +5185,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4006" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="super breakout.rom" size="8192" crc="4da14cf9" sha1="e0e3cfee1deec5f57fcbd3c98f61225913fc6fb7" offset="0" /> <!-- Verified -->
@@ -5198,7 +5198,7 @@ Compiled by K1W1
 		<year>199?</year>
 		<publisher>Unerring Master</publisher>
 		<info name="usage" value="Requires the Atari Super Turbo hardware modification (or compatible ATT, UM) installed in a tape recorder. " />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_blizzard" />
 			<dataarea name="rom" size="16384">
 				<rom name="super cartridge.rom" size="16384" crc="a68aa4a5" sha1="9a9bcf1a2135a6c6fdacd85685c08b52f6cd0c74" offset="0" />
@@ -5211,7 +5211,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Parker Brothers</publisher>
 		<info name="serial" value="1140" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="super cobra.rom" size="8192" crc="2af38d2f" sha1="5417f31e11e9b07cb35bd7454b3b9dbe8da53827" offset="0" /> <!-- Verified -->
@@ -5223,7 +5223,7 @@ Compiled by K1W1
 		<description>Super E-Burner</description>
 		<year>1992</year>
 		<publisher>CSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="super e-burner.rom" size="8192" crc="21516e15" sha1="f81598ee460a7f1d643df49a92424e9084b3b7e5" offset="0" />
@@ -5235,7 +5235,7 @@ Compiled by K1W1
 		<description>Super Pac-Man (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="super pac-man (proto).rom" size="16384" crc="4b9b00f5" sha1="fc67c588060fe85eb169b5e7467f8b96772afcce" offset="0" />
@@ -5249,7 +5249,7 @@ Compiled by K1W1
 		<publisher>PPI</publisher>
 		<info name="serial" value="G2300" />
 		<info name="usage" value="Personal Peripherals Inc. Super Sketch device required" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="super sketch graphics master.rom" size="8192" crc="0e1c20c5" sha1="73272680f87ae4af625b99144b561864eb59f596" offset="0" /> <!-- Verified -->
@@ -5263,7 +5263,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Synapse</publisher>
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="synassmbler.rom" size="8192" crc="6aa6b6d6" sha1="4a7232b4e121a546cbb6b7e11a2d7cf7ebd7a300" offset="0" status="baddump" />
@@ -5276,7 +5276,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="012-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="super zaxxon.rom" size="16384" crc="9e64e13b" sha1="60752c2cfed01095ec01be96b15977166509503e" offset="0" /> <!-- Verified -->
@@ -5288,7 +5288,7 @@ Compiled by K1W1
 		<description>Superman III (Prototype)</description>
 		<year>1983</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="superman iii (proto).rom" size="16384" crc="639846d6" sha1="bbb315e92b5508a7fb14e5a8b83ebd9f44997f5d" offset="0" />
@@ -5301,7 +5301,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>IDSI</publisher>
 		<info name="serial" value="ID2103" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="survival of the fittest.rom" size="8192" crc="7f48fbc5" sha1="d585d92eb5f471a485576ab702bd070cad742a4a" offset="0" />
@@ -5313,7 +5313,7 @@ Compiled by K1W1
 		<description>Tamlilan (Hebrew Text Editor)</description>
 		<year>19??</year>
 		<publisher>Aram</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="tamlilan.rom" size="16384" crc="f7da90b0" sha1="d5e4c8437600052d64160f0d635fa4c468a9dcd8" offset="0" />
@@ -5326,7 +5326,7 @@ Compiled by K1W1
 		<year>1986</year>
 		<publisher>COVIDEA</publisher>
 		<info name="usage" value="Modem required (and a working Chemical Bank service, obviously inactive for decades)" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="target electronic banking.rom" size="16384" crc="60c2a5ae" sha1="3c4976c118a9aefba8f8895e9b8c818dbc641371" offset="0" />
@@ -5340,7 +5340,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4015" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="telelink 1.rom" size="8192" crc="bb648a61" sha1="172ab373068cf28cd0bade302d79880757b90d9c" offset="0" /> <!-- Verified -->
@@ -5354,7 +5354,7 @@ Compiled by K1W1
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4016" />
 		<sharedfeat name="compatibility" value="OSb"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_tlink2" />
 			<dataarea name="rom" size="8192">
 				<rom name="telelink 2.rom" size="8192" crc="f0163f90" sha1="15d1dc9591b7306453087c94746ba1622e46d0ad" offset="0" /> <!-- Verified -->
@@ -5366,7 +5366,7 @@ Compiled by K1W1
 		<description>Test Atari 65-130XE R.2</description>
 		<year>1986</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="test atari 65-130xe r.2 (atari)(1986).rom" size="8192" crc="0b0b43f8" sha1="c20394f2a9c9a8bd8228dd09a33ed92abb0c685d" offset="0" />
@@ -5379,7 +5379,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CC-102-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="the designer's pencil.rom" size="16384" crc="6ed64678" sha1="ecff0515340a0fe0f072f74ed3996cf2adc053ad" offset="0" /> <!-- Verified -->
@@ -5392,7 +5392,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-005-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="the dreadnaught factor.rom" size="8192" crc="c26fbb5b" sha1="e6da0ac55054f43ab612345d787a1ff2b505383a" offset="0" /> <!-- Verified -->
@@ -5404,7 +5404,7 @@ Compiled by K1W1
 		<description>Das Thera-Med Zahnschutz-Spiel</description>
 		<year>1984</year>
 		<publisher>Henkel Cosmetics</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="thera-med zahnschutz-spiel, das.rom" size="8192" crc="10df011f" sha1="5cd6905ae627a8549640c83eb31f015b1cf4947b" offset="0" />
@@ -5416,7 +5416,7 @@ Compiled by K1W1
 		<description>The Last Starfighter (Prototype)</description>
 		<year>1984</year>
 		<publisher>Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="the last starfighter (proto).rom" size="16384" crc="3267eba7" sha1="7451b20259450f55ec68d99328fe917f50e04584" offset="0" />
@@ -5429,7 +5429,7 @@ Compiled by K1W1
 		<year>1985</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8080" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="the learning phone.rom" size="8192" crc="5b101922" sha1="4808b54b0671f94cd995f4230aacf0496bf9a1c1" offset="0" /> <!-- Verified -->
@@ -5443,7 +5443,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Eastern House</publisher>
 		<info name="usage" value="You must type 'X=USR(32768)' from the BASIC prompt to initialize it." />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k_right" />
 			<dataarea name="rom" size="8192">
 				<rom name="the monkey wrench 2 xl.rom" size="8192" crc="69fd5f8b" sha1="a352188014b06e86ab353cc7fefbcbc49c5c010c" offset="0" />
@@ -5457,7 +5457,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Eastern House</publisher>
 		<sharedfeat name="compatibility" value="Right Slot"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k_right" />
 			<dataarea name="rom" size="8192">
 				<rom name="the monkey wrench 2.rom" size="8192" crc="7191a903" sha1="318a3e7629565db8554a627da56e778a2c0155a9" offset="0" /> <!-- Verified -->
@@ -5471,7 +5471,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Eastern House</publisher>
 		<sharedfeat name="compatibility" value="Right Slot"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k_right" />
 			<dataarea name="rom" size="8192">
 				<rom name="monkey wrench 2 (a).rom" size="8192" crc="a315afb6" sha1="83e0bda91748bf5527ef0a3b36f52b0671f90f6a" offset="0" />
@@ -5485,7 +5485,7 @@ Compiled by K1W1
 		<year>1981</year>
 		<publisher>Eastern House</publisher>
 		<sharedfeat name="compatibility" value="Right Slot"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k_right" />
 			<dataarea name="rom" size="8192">
 				<rom name="the monkey wrench.rom" size="8192" crc="147541a4" sha1="d397911ef8828a5ebc4e366e38b80a42fa42f169" offset="0" /> <!-- Verified -->
@@ -5498,7 +5498,7 @@ Compiled by K1W1
 		<!-- This cartridge requires the Writer's Tool disk software. It's basic function appears to be as a copy protection dongle for the disk software. -->
 		<year>1985</year>
 		<publisher>OSS</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_oss8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="the writer's tool.rom" size="8192" crc="13bcf201" sha1="7de7b160c60f162b19f45789db07ddfd13836da2" offset="0" />
@@ -5521,7 +5521,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-0111" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="timebound.rom" size="16384" crc="d3e98044" sha1="df971026c7e7be858e60a7e6e254738d003dfa58" offset="0" /> <!-- Verified -->
@@ -5533,7 +5533,7 @@ Compiled by K1W1
 		<description>Topper</description>
 		<year>1982</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="topper.rom" size="16384" crc="0286eea6" sha1="7e127d80dc7a7b38cc842b0d4cb653c24cb07c70" offset="0" /> <!-- Verified -->
@@ -5547,7 +5547,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8069" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<feature name="peripheral" value="trackfld" /> <!-- Works with Track &amp; Field controller -->
 			<dataarea name="rom" size="16384">
@@ -5560,7 +5560,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C1 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c1.rom" size="65536" crc="360a47b3" sha1="0f58e467e46c70f96c4c757f4e2031c0d44855c8" offset="0" />
@@ -5572,7 +5572,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C2 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo64" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c2.rom" size="65536" crc="ade93e66" sha1="02e24a1444e6d4ee3ab8dae5cba58724f5cbb34f" offset="0" />
@@ -5584,7 +5584,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C3 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c3.rom" size="65536" crc="bedf99fe" sha1="7a51c4e1e473431c8795fe6d8407fee6fce034d8" offset="0" />
@@ -5596,7 +5596,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C4 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c4.rom" size="65536" crc="97a8c904" sha1="dc13ec8759ae7482d66fd8c9208a53cf43de5f18" offset="0" />
@@ -5608,7 +5608,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C5 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c5.rom" size="65536" crc="78dbb563" sha1="a9a324ef33887bac5ab144349630bf353cc182c8" offset="0" />
@@ -5620,7 +5620,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge C6 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge c6.rom" size="65536" crc="49e18f6e" sha1="fe780141e181cef71c5833a7f027272dafc3225e" offset="0" />
@@ -5632,7 +5632,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D1 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d1.rom" size="131072" crc="4d1dd418" sha1="91a2e78abe4f3bfa0a95d2248e988c556fe8a5c8" offset="0" />
@@ -5644,7 +5644,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D2 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d2.rom" size="131072" crc="025ab67a" sha1="d456adb1c53f24e15a88c00a54b33ad22c9e7fcf" offset="0" />
@@ -5656,7 +5656,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D3 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d3.rom" size="131072" crc="bca7d11b" sha1="fb75c42cc1c896aaabda7e9591a45fe9a2f3a8e8" offset="0" />
@@ -5669,7 +5669,7 @@ Compiled by K1W1
 		<!-- Half of the games don't run. Possible Bad dump. -->
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d4 [b].rom" size="131072" crc="72df4a5e" sha1="519abe32c6c3ee09ec8f027790da4d51157ba468" offset="0" status="baddump" />
@@ -5681,7 +5681,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D5 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d5.rom" size="131072" crc="a5aee6fd" sha1="136bfa432b5ab340c332019e8ceb847f4afd1b03" offset="0" />
@@ -5693,7 +5693,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D6 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d6.rom" size="131072" crc="5498c7dc" sha1="e2ee9d60d4ce806ff822ca14d45758a26d4502cf" offset="0" />
@@ -5705,7 +5705,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D7 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge d7.rom" size="131072" crc="3fb92d9e" sha1="f4c492b2c47c14bb5c8e2e3351b2b79d07395260" offset="0" />
@@ -5717,7 +5717,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge D8 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge d8.rom" size="65536" crc="3d68152e" sha1="84c215aa71d2cb94b11f6b6859af8d3c2e65b3cc" offset="0" />
@@ -5729,7 +5729,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge E1 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge e1.rom" size="131072" crc="fa100cbf" sha1="c016952dc27960e33de3f0e652b8f4147d97d212" offset="0" />
@@ -5741,7 +5741,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge E2 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_turbo128" />
 			<dataarea name="rom" size="131072">
 				<rom name="turbocartridge e2.rom" size="131072" crc="bede95cd" sha1="0d1ab2d43fc71ee5c0f55f9dc6e893a651ae7a62" offset="0" />
@@ -5753,7 +5753,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge X1 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge x1.rom" size="65536" crc="1dccc2c7" sha1="5e9ca706bbd9af33f260962e648b27f48a4b97fa" offset="0" />
@@ -5765,7 +5765,7 @@ Compiled by K1W1
 		<description>Turbo Cartridge X2 (Spa, Pirate)</description>
 		<year>19??</year>
 		<publisher>Turbosoft</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="turbocartridge x2.rom" size="65536" crc="11f334dc" sha1="1af66bdb23a4df4b4c324ac2994dd239888ab588" offset="0" />
@@ -5777,7 +5777,7 @@ Compiled by K1W1
 		<description>Turbo System</description>
 		<year>1993</year>
 		<publisher>Dadok</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_phoenix" />
 			<dataarea name="rom" size="8192">
 				<rom name="turbo system.rom" size="8192" crc="da021439" sha1="14eaba8a6105d0ad9f8d05def5acc32fe89a2d76" offset="0" />
@@ -5790,7 +5790,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33005" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="turmoil.rom" size="8192" crc="fe48aadf" sha1="f7a22a9c750d1df595272231bc9cc2568420b9a8" offset="0" /> <!-- Verified -->
@@ -5803,7 +5803,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Romox / London Software</publisher>
 		<info name="serial" value="ECPC-02213" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="trion.rom" size="16384" crc="2c42362f" sha1="10e5c565deff279b907755d015d2b1e499993482" offset="0" />
@@ -5815,7 +5815,7 @@ Compiled by K1W1
 		<description>Twin Pack</description>
 		<year>1998</year>
 		<publisher>Video 61</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="twin pack.rom" size="8192" crc="cd9f91cb" sha1="47c486eec10923f5c9190614da4118665b6c9973" offset="0" />
@@ -5827,7 +5827,7 @@ Compiled by K1W1
 		<description>Typo</description>
 		<year>1982</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="typo.rom" size="8192" crc="70585854" sha1="a6d3de8600f460e6912385a7cccfc7797cdda4e4" offset="0" />
@@ -5840,7 +5840,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="RX8057" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="typo attack.rom" size="8192" crc="ed6f714c" sha1="106f2a3680f27955b231edcf911529faa8d2f2ab" offset="0" /> <!-- Verified -->
@@ -5853,7 +5853,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Spinnaker</publisher>
 		<info name="serial" value="UFG-AT" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="up for grabs.rom" size="8192" crc="9893ae7a" sha1="9e4774f5213579b814926d9c940a8c7f090f2c62" offset="0" />
@@ -5866,7 +5866,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="009-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="up 'n down.rom" size="16384" crc="53ea3bf6" sha1="1a1833abf8961d5b0c68a93785ead6121c3adeaf" offset="0" /> <!-- Verified -->
@@ -5878,7 +5878,7 @@ Compiled by K1W1
 		<description>Up Up and Away (Prototype)</description>
 		<year>1983</year>
 		<publisher>Ringblack Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="up up and away (proto).rom" size="16384" crc="a8261044" sha1="5d9988c4305213356f9459a900bcd411a5db43cb" offset="0" />
@@ -5891,7 +5891,7 @@ Compiled by K1W1
 		<year>1979</year>
 		<publisher>Atari</publisher>
 		<info name="serial" value="CXL4005" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="video easel.rom" size="8192" crc="276d7acc" sha1="d288675f4de7696e729125c2b3b2cb8887f042f2" offset="0" /> <!-- Verified -->
@@ -5904,7 +5904,7 @@ Compiled by K1W1
 		<year>1993</year>
 		<publisher>JRC</publisher>
 		<sharedfeat name="compatibility" value="XL/XE"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_phoenix" />
 			<dataarea name="rom" size="8192">
 				<rom name="visicopy3.rom" size="8192" crc="0aa5ffdb" sha1="15b7e13446f4259a17bf911c7f9e34d622310dac" offset="0" />
@@ -5916,7 +5916,7 @@ Compiled by K1W1
 		<description>Video Poker Card Game</description>
 		<year>1998</year>
 		<publisher>Video 61 / Atari</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="video poker card game.rom" size="16384" crc="dc492963" sha1="55c6ed5c2388a8cd228bc9fd5a69fa93180ee7ea" offset="0" />
@@ -5929,7 +5929,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>CBS Software</publisher>
 		<info name="serial" value="4L-9700" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="webster - the word game.rom" size="8192" crc="6fffb4a9" sha1="48563de83e2217cc01fb13503deece29baca8272" offset="0" /> <!-- Verified -->
@@ -5941,7 +5941,7 @@ Compiled by K1W1
 		<description>Weltraumkolonie (Ger)</description>
 		<year>1984</year>
 		<publisher>Spinnaker / Ravensburger</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="weltraumkolonie.rom" size="8192" crc="06fd2cdb" sha1="865c2255a5eb02f9cbd801e54a4ba252544d2302" offset="0" />
@@ -5953,7 +5953,7 @@ Compiled by K1W1
 		<description>Whiz Kid</description>
 		<year>1983</year>
 		<publisher>Romox</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="whiz kid.rom" size="8192" crc="11c2c963" sha1="aee11312bf19153e0f20ee0c19b1ce4f0f87b79c" offset="0" />
@@ -5965,7 +5965,7 @@ Compiled by K1W1
 		<description>Wizard of Wor</description>
 		<year>1983</year>
 		<publisher>Roklan</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="wizard of wor.rom" size="16384" crc="8017e56a" sha1="b4447b12d04c907eea66f6c09629408e847b2305" offset="0" /> <!-- Verified -->
@@ -5978,7 +5978,7 @@ Compiled by K1W1
 		<year>1982</year>
 		<publisher>Sirius</publisher>
 		<info name="serial" value="33002" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="worm war 1.rom" size="8192" crc="d9b120f4" sha1="b7517334bdaf111a8afa8b2536db3c43e76b2b5c" offset="0" /> <!-- Verified -->
@@ -5990,7 +5990,7 @@ Compiled by K1W1
 		<description>Yie Another Kung-Fu</description>
 		<year>2011</year>
 		<publisher>GR8 Software</publisher>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_corina" />
 			<dataarea name="rom" size="1056768">
 				<rom name="yie another kung-fu.rom" size="1056768" crc="8ed7da2d" sha1="5f315d358d9680eb1cc9531276d649ab1f599aab" offset="0" />
@@ -6003,7 +6003,7 @@ Compiled by K1W1
 		<year>1983</year>
 		<publisher>Sega</publisher>
 		<info name="serial" value="008-03" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="zaxxon.rom" size="16384" crc="21579706" sha1="5604b114476c14d256324f80355aa6cfc410570c" offset="0" /> <!-- Verified -->
@@ -6016,7 +6016,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CZ-010-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_8k" />
 			<dataarea name="rom" size="8192">
 				<rom name="zenji.rom" size="8192" crc="ebc6ec2e" sha1="48e358d1688e672ae4798c8751c9d886e4ed817c" offset="0" /> <!-- Verified -->
@@ -6029,7 +6029,7 @@ Compiled by K1W1
 		<year>1984</year>
 		<publisher>Activision</publisher>
 		<info name="serial" value="CC-101-04" />
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_16k" />
 			<dataarea name="rom" size="16384">
 				<rom name="zone ranger.rom" size="16384" crc="1b6c7b78" sha1="bd5c67f16132af3b60f78f47c3a337382ff94618" offset="0" /> <!-- Verified -->
@@ -6042,7 +6042,7 @@ Compiled by K1W1
 		<year>1999</year>
 		<publisher>Video 61 / Williams</publisher>
 		<sharedfeat name="compatibility" value="XL/XE"/>
-		<part name="cart" interface="a8bit_cart">
+		<part name="cart1" interface="a8bit_cart">
 			<feature name="slot" value="a800_williams" />
 			<dataarea name="rom" size="65536">
 				<rom name="zybex.rom" size="65536" crc="c1da182c" sha1="f77c897e6461e0ceab7e3922c233319e7c4cd601" offset="0" />


### PR DESCRIPTION
Changed part name to "cart1" from "cart" to ensure MAMEHub uses the correct command line switch to start a800 games.

All systems with multiple  cartridge slots may have this problem (eg: MSX).

Re-audit your games after downloading the patch to activate this fix.
